### PR TITLE
fix: add configurability to azure helm chart user assigned identity

### DIFF
--- a/nxrm-azure-ha-helm/templates/secret.yaml
+++ b/nxrm-azure-ha-helm/templates/secret.yaml
@@ -23,7 +23,7 @@ spec:
   parameters:
     keyvaultName: {{.Values.secret.keyvaultName}}
     useVMManagedIdentity: "true"
-    userAssignedIdentityID: "dcf99d84-bd2e-4f51-82cc-e32a96a3349c"
+    userAssignedIdentityID: {{ .Values.secret.userAssignedIdentityID }}
     objects: |
       array:
         - |

--- a/nxrm-azure-ha-helm/values.yaml
+++ b/nxrm-azure-ha-helm/values.yaml
@@ -97,6 +97,9 @@ service:  #Nexus Repo NodePort Service
     port: 9090
     targetPort: 8081
 secret:
+  # userAssignedIdentityID: a managed identity or service principal that
+  # has secrets management access to the key vault
+  userAssignedIdentityID: "userAssignedIdentityID"
   tenandId: "tenantId"
   keyvaultName: keyvaultname
   provider: azure


### PR DESCRIPTION
Ran into an issue that would seemingly block others from using the hosted chart since the managed identity was not configurable outside of editing the locally cloned chart `secret.yaml`.