### PR TITLE
Allow alternative options instead of secrets-store CSI driver

### DIFF
--- a/nxrm-aws-ha-helm/templates/secret.yaml
+++ b/nxrm-aws-ha-helm/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.secret.secretsstore.enabled }}
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
@@ -22,9 +23,9 @@ spec:
     type: Opaque
   parameters:
     objects:  |
-        - objectName: "{{ .Values.secret.license.arn }}"
-          objectAlias: "{{ .Values.secret.license.alias }}"
-        - objectName: "{{ .Values.secret.rds.arn }}"
+        - objectName: "{{ .Values.secret.secretsstore.license.arn }}"
+          objectAlias: "{{ .Values.secret.secretsstore.license.alias }}"
+        - objectName: "{{ .Values.secret.secretsstore.rds.arn }}"
           jmesPath:
             - path: "username"
               objectAlias: "nxrm-db-user"
@@ -32,7 +33,8 @@ spec:
               objectAlias: "nxrm-db-password"
             - path: "host"
               objectAlias: "nxrm-db-host"
-        - objectName: "{{ .Values.secret.adminpassword.arn }}"
+        - objectName: "{{ .Values.secret.secretstore.adminpassword.arn }}"
           jmesPath:
            - path: "admin_nxrm_password"
              objectAlias: "nxrm-admin-password"
+{{- end }}

--- a/nxrm-aws-ha-helm/templates/statefulset.yaml
+++ b/nxrm-aws-ha-helm/templates/statefulset.yaml
@@ -76,13 +76,13 @@ spec:
             - name: NEXUS_SECURITY_RANDOMPASSWORD
               value: "false"
             - name: INSTALL4J_ADD_VM_PARAMS
-              value: "{{ .Values.statefulset.container.env.install4jAddVmParams }} -Dnexus.licenseFile=/nxrm-secrets/{{ .Values.secret.license.alias }} \
+              value: "{{ .Values.statefulset.container.env.install4jAddVmParams }} -Dnexus.licenseFile=/{{ .Values.license.path }}/{{ .Values.license.filename }} \
           -Dnexus.datastore.clustered.enabled=true -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs \
           -Dnexus.datastore.nexus.jdbcUrl=jdbc:postgresql://${DB_HOST}:{{ .Values.statefulset.container.env.nexusDBPort }}/${DB_NAME} \
           -Dnexus.datastore.nexus.username=${DB_USER} \
           -Dnexus.datastore.nexus.password=${DB_PASSWORD}"
           volumeMounts:
-            - mountPath: /nxrm-secrets
+            - mountPath: /{{ .Values.license.path }}
               name: nxrm-secrets
             - name: nexus-data
               mountPath: /nexus-data
@@ -114,6 +114,7 @@ spec:
           resources:
             {{ toYaml .Values.statefulset.taskLogContainer.resources | nindent 12 }}
       volumes:
+        {{- if .Values.secret.secretsstore.enabled }}
         - name: nxrm-secrets
           csi:
             driver: secrets-store.csi.k8s.io
@@ -121,12 +122,16 @@ spec:
             volumeAttributes:
               secretProviderClass: {{ .Chart.Name }}-{{ .Chart.Version }}.{{ .Release.Name }}-secret
               fsType: ext4
+        {{- end }}
         - name: logback-tasklogfile-override
           configMap:
             name: {{ .Chart.Name }}-{{ .Chart.Version }}.{{ .Release.Name }}-logback-tasklogfile-override
             items:
               - key: logback-tasklogfile-appender-override.xml
                 path: logback-tasklogfile-appender-override.xml
+        {{- with .Values.statefulset.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: nexus-data

--- a/nxrm-aws-ha-helm/values.yaml
+++ b/nxrm-aws-ha-helm/values.yaml
@@ -78,6 +78,7 @@ statefulset:
       requests:
         cpu: "0.1"
         memory: "256Mi"
+  volumes: []
 serviceAccount:
   name: nexus-repository-deployment-sa #This service account in managed by Helm
   role: arn:aws:iam::000000000000:role/nxrm-nexus-role #Role created in the "AWS Secrets Manager" section of the HA documentation
@@ -124,11 +125,18 @@ service:  #Nexus Repo NodePort Service
     protocol: TCP
     port: 9090
     targetPort: 8081
+
+license:
+  path: nxrm-secrets
+  filename: nxrm-license.lic
+
 secret:
-  license:
-    arn: arn:aws:secretsmanager:us-east-1:000000000000:secret:nxrm-nexus-license
-    alias: nxrm-license.lic
-  rds:
-    arn: arn:aws:secretsmanager:us-east-1:000000000000:secret:nxrmrds-cred-nexus
-  adminpassword:
-    arn: arn:aws:secretsmanager:us-east-1:000000000000:secret:admin-nxrm-password
+  secretsstore:
+    enabled: true
+    license:
+      arn: arn:aws:secretsmanager:us-east-1:000000000000:secret:nxrm-nexus-license
+      alias: nxrm-license.lic
+    rds:
+      arn: arn:aws:secretsmanager:us-east-1:000000000000:secret:nxrmrds-cred-nexus
+    adminpassword:
+      arn: arn:aws:secretsmanager:us-east-1:000000000000:secret:admin-nxrm-password


### PR DESCRIPTION
Hi @bobotimi ,

I've submitted a pull request that addresses the deactivation of secrets-store related configurations, specifically for cases where options like external-secrets are used instead of the secrets-store CSI driver.

Would you mind reviewing it when you have a moment? Thank you!