### PR TITLE
Refactoring docker ingress annotations

### DIFF
--- a/nxrm-ha/templates/ingress.yaml
+++ b/nxrm-ha/templates/ingress.yaml
@@ -79,7 +79,7 @@ metadata:
         {{ toYaml . | nindent 4 }}
       {{- end }}
     {{- end }}
-  {{- with $.Values.ingress.annotations }}
+  {{- with $registry.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/nxrm-ha/tests/ingress_test.yaml
+++ b/nxrm-ha/tests/ingress_test.yaml
@@ -472,9 +472,6 @@ tests:
     set:
       ingress:
         ingressClassName: nginx
-        annotations:
-          jar: box
-          super: ted
       nexus:
         docker:
           enabled: true
@@ -483,6 +480,9 @@ tests:
              port: 5000
              secretName: registry-secret
              targetPort: 8081
+             annotations:
+               jar: box
+               super: ted
         extraLabels:
           foo: bar
           baz: bay

--- a/nxrm-ha/values.yaml
+++ b/nxrm-ha/values.yaml
@@ -263,6 +263,7 @@ nexus:
   #     port: 5000
   #     secretName: registry-secret
   #     targetPort: 8081
+  #     annotations: {}
 
 # Enable configmap and add arbitrary data in configmap
 config:


### PR DESCRIPTION
The annotations in the 'ingress' section are not used anymore for docker ingress objects. They are now part of an `Values.nexus.docker.registries` entry.
With this change its now possible to define annotations on a docker registry level. This is helpfull if annotations like `external-dns.alpha.kubernetes.io/hostname` must be used, where each hostname is distinct for each ingress object created.