### PR TITLE
iday - Support external secret operator

### DIFF
--- a/nxrm-ha/templates/database-secret.yaml
+++ b/nxrm-ha/templates/database-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.secret.dbSecret.enabled (not .Values.aws.secretmanager.enabled) (not .Values.azure.keyvault.enabled) }}
+{{- if and .Values.secret.dbSecret.enabled (not .Values.aws.secretmanager.enabled) (not .Values.azure.keyvault.enabled) (not .Values.externalsecrets.enabled) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/nxrm-ha/templates/eso-admin-secrets.yaml
+++ b/nxrm-ha/templates/eso-admin-secrets.yaml
@@ -1,0 +1,33 @@
+{{- if and (not .Values.aws.secretmanager.enabled) (not .Values.azure.keyvault.enabled) (not .Values.secret.nexusAdminSecret.enabled) }}
+{{- if .Values.externalsecrets.enabled  }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ template "nexus.name" . }}-external-adminsecret
+  namespace: {{ .Values.namespaces.nexusNs.name }}
+  labels: {{- include "nexus.labels" . | nindent 4 }}
+  {{- if .Values.nexus.extraLabels }}
+    {{- with .Values.nexus.extraLabels }}
+      {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  refreshInterval: {{ .Values.externalsecrets.secrets.admin.refreshInterval }}
+  secretStoreRef:
+    kind: SecretStore
+    name: {{ template "nexus.name" . }}-{{ .Values.externalsecrets.secretstore.name }}
+  target:
+    name: {{ template "nexus.name" . }}-adminsecret
+    creationPolicy: Owner
+  data:
+    - secretKey: nexus-admin-password
+      remoteRef:
+        {{- if .Values.externalsecrets.secrets.admin.valueIsJson }}
+        key: {{ .Values.externalsecrets.secrets.admin.providerSecretName }}
+        property: {{ .Values.externalsecrets.secrets.admin.adminPasswordKey }}
+        {{ else }}
+        key: {{ .Values.externalsecrets.secrets.admin.adminPasswordKey }}
+        {{- end }}
+{{- end }}
+{{- end }}
+

--- a/nxrm-ha/templates/eso-database-secrets.yaml
+++ b/nxrm-ha/templates/eso-database-secrets.yaml
@@ -1,0 +1,49 @@
+{{- if and (not .Values.aws.secretmanager.enabled) (not .Values.azure.keyvault.enabled) (not .Values.secret.dbSecret.enabled) }}
+{{- if .Values.externalsecrets.enabled  }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ template "nexus.name" . }}-external-dbsecret
+  namespace: {{ .Values.namespaces.nexusNs.name }}
+  labels: {{- include "nexus.labels" . | nindent 4 }}
+  {{- if .Values.nexus.extraLabels }}
+    {{- with .Values.nexus.extraLabels }}
+      {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  refreshInterval: {{ .Values.externalsecrets.secrets.database.refreshInterval }}
+  secretStoreRef:
+    kind: SecretStore
+    name: {{ template "nexus.name" . }}-{{ .Values.externalsecrets.secretstore.name }}
+  target:
+    name: {{ template "nexus.name" . }}-dbsecret
+    creationPolicy: Owner
+  data:
+    - secretKey: db-user
+      remoteRef:
+        {{- if .Values.externalsecrets.secrets.database.valueIsJson }}
+        key: {{ .Values.externalsecrets.secrets.database.providerSecretName }}
+        property: {{ .Values.externalsecrets.secrets.database.dbUserKey }}
+        {{ else }}
+        key: {{ .Values.externalsecrets.secrets.database.dbUserKey}}
+        {{- end }}
+    - secretKey: db-password
+      remoteRef:
+        {{- if .Values.externalsecrets.secrets.database.valueIsJson }}
+        key: {{ .Values.externalsecrets.secrets.database.providerSecretName }}
+        property: {{ .Values.externalsecrets.secrets.database.dbPasswordKey }}
+        {{ else }}
+        key: {{ .Values.externalsecrets.secrets.database.dbPasswordKey}}
+        {{- end }}
+    - secretKey: db-host
+      remoteRef:
+        {{- if .Values.externalsecrets.secrets.database.valueIsJson }}
+        key: {{ .Values.externalsecrets.secrets.database.providerSecretName }}
+        property: {{ .Values.externalsecrets.secrets.database.dbHostKey}}
+        {{ else }}
+        key: {{ .Values.externalsecrets.secrets.database.dbHostKey}}
+        {{- end }}
+{{- end }}
+{{- end }}
+

--- a/nxrm-ha/templates/eso-license-secrets.yaml
+++ b/nxrm-ha/templates/eso-license-secrets.yaml
@@ -1,0 +1,31 @@
+{{- if and (not .Values.aws.secretmanager.enabled) (not .Values.azure.keyvault.enabled) (not .Values.secret.license.licenseSecret.enabled) }}
+{{- if .Values.externalsecrets.enabled  }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ template "nexus.name" . }}-external-{{ .Values.secret.license.name }}
+  namespace: {{ .Values.namespaces.nexusNs.name }}
+  labels: {{- include "nexus.labels" . | nindent 4 }}
+  {{- if .Values.nexus.extraLabels }}
+    {{- with .Values.nexus.extraLabels }}
+      {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  refreshInterval: {{ .Values.externalsecrets.secrets.license.refreshInterval }}
+  secretStoreRef:
+    kind: SecretStore
+    name: {{ template "nexus.name" . }}-{{ .Values.externalsecrets.secretstore.name }}
+  target:
+    name: {{ .Values.secret.license.name }}
+    creationPolicy: Owner
+  data:
+    - secretKey: {{ .Values.secret.license.name }}
+      remoteRef:
+        key: {{ .Values.externalsecrets.secrets.license.providerSecretName }}
+        {{- if .Values.externalsecrets.secrets.license.decodingStrategy }}
+        decodingStrategy: {{ .Values.externalsecrets.secrets.license.decodingStrategy }}
+        {{- end }}
+{{- end }}
+{{- end }}
+

--- a/nxrm-ha/templates/eso-nexus-secrets.yaml
+++ b/nxrm-ha/templates/eso-nexus-secrets.yaml
@@ -1,0 +1,31 @@
+{{- if and (not .Values.secret.aws.nexusSecret.enabled ) (not .Values.secret.azure.nexusSecret.enabled) (not .Values.secret.nexusSecret.enabled) }}
+{{- if and .Values.externalsecrets.enabled .Values.externalsecrets.secrets.nexusSecret.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ template "nexus.name" . }}-external-{{ .Values.secret.nexusSecret.name }}
+  namespace: {{ .Values.namespaces.nexusNs.name }}
+  labels: {{- include "nexus.labels" . | nindent 4 }}
+  {{- if .Values.nexus.extraLabels }}
+    {{- with .Values.nexus.extraLabels }}
+      {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  refreshInterval: {{ .Values.externalsecrets.secrets.nexusSecret.refreshInterval }}
+  secretStoreRef:
+    kind: SecretStore
+    name: {{ template "nexus.name" . }}-{{ .Values.externalsecrets.secretstore.name }}
+  target:
+    name: {{ .Values.secret.nexusSecret.name }}
+    creationPolicy: Owner
+  data:
+    - secretKey: {{ .Values.secret.nexusSecret.name }}
+      remoteRef:
+        key: {{ .Values.externalsecrets.secrets.nexusSecret.providerSecretName }}
+        {{- if .Values.externalsecrets.secrets.nexusSecret.decodingStrategy }}
+        decodingStrategy: {{ .Values.externalsecrets.secrets.nexusSecret.decodingStrategy }}
+        {{- end }}
+{{- end }}
+{{- end }}
+

--- a/nxrm-ha/templates/eso-secret-store.yaml
+++ b/nxrm-ha/templates/eso-secret-store.yaml
@@ -1,0 +1,20 @@
+{{- if and (not .Values.aws.secretmanager.enabled) (not .Values.azure.keyvault.enabled) (not .Values.secret.dbSecret.enabled) }}
+{{- if .Values.externalsecrets.enabled  }}
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: {{ template "nexus.name" . }}-{{ .Values.externalsecrets.secretstore.name }}
+  namespace: {{ .Values.namespaces.nexusNs.name }}
+  labels: {{- include "nexus.labels" . | nindent 4 }}
+  {{- if .Values.nexus.extraLabels }}
+    {{- with .Values.nexus.extraLabels }}
+      {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  provider:
+  {{- with .Values.externalsecrets.secretstore.spec.provider }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/nxrm-ha/templates/license-config-mapping.yaml
+++ b/nxrm-ha/templates/license-config-mapping.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.secret.license.licenseSecret.enabled }}
+{{- if and .Values.secret.license.licenseSecret.enabled (not .Values.azure.keyvault.enabled) (not .Values.aws.secretmanager.enabled) (not .Values.externalsecrets.enabled) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/nxrm-ha/templates/nexus-admin-secret.yaml
+++ b/nxrm-ha/templates/nexus-admin-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.secret.nexusAdminSecret.enabled (not .Values.aws.secretmanager.enabled) (not .Values.azure.keyvault.enabled) }}
+{{- if and .Values.secret.nexusAdminSecret.enabled (not .Values.aws.secretmanager.enabled) (not .Values.azure.keyvault.enabled) (not .Values.externalsecrets.enabled) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/nxrm-ha/templates/nexus-secret-mapping.yaml
+++ b/nxrm-ha/templates/nexus-secret-mapping.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.secret.nexusSecret.enabled (not .Values.secret.aws.nexusSecret.enabled ) (not .Values.secret.azure.nexusSecret.enabled) }}
+{{- if and .Values.secret.nexusSecret.enabled (not .Values.secret.aws.nexusSecret.enabled ) (not .Values.secret.azure.nexusSecret.enabled) (not .Values.externalsecrets.enabled) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/nxrm-ha/templates/secretprovider.yaml
+++ b/nxrm-ha/templates/secretprovider.yaml
@@ -1,4 +1,5 @@
 {{- if or .Values.aws.secretmanager.enabled .Values.azure.keyvault.enabled  }}
+{{- if (not .Values.externalsecrets.enabled) }}
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
@@ -107,5 +108,6 @@ spec:
           objectName: {{ .Values.secret.nexusAdmin.name }}
           objectType: secret
     tenantId: {{ .Values.secret.azure.tenantId }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/nxrm-ha/templates/serviceaccount.yaml
+++ b/nxrm-ha/templates/serviceaccount.yaml
@@ -5,6 +5,11 @@ metadata:
   name: {{ include "nexus.serviceAccountName" . }}
   namespace: {{ default .Release.Namespace .Values.namespaces.nexusNs.name | quote }}
   labels: {{- include "nexus.labels" . | nindent 4 }}
+  {{- if .Values.serviceAccount.labels }}
+    {{- with .Values.serviceAccount.labels}}
+      {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
   {{- if .Values.nexus.extraLabels }}
     {{- with .Values.nexus.extraLabels }}
       {{ toYaml . | nindent 4 }}

--- a/nxrm-ha/templates/statefulset.yaml
+++ b/nxrm-ha/templates/statefulset.yaml
@@ -145,7 +145,7 @@ spec:
             - name: NEXUS_ZERO_DOWNTIME_ENABLED
           {{- $zeroDowntimeEnabled := default false .Values.statefulset.container.env.zeroDowntimeEnabled }}
               value: "{{ toString $zeroDowntimeEnabled }}"
-          {{- if .Values.secret.nexusSecret.enabled }}
+          {{- if or .Values.secret.nexusSecret.enabled (and .Values.externalsecrets.enabled .Values.externalsecrets.secrets.nexusSecret.enabled ) }}
             - name: NEXUS_SECRETS_KEY_FILE
           {{ if or (and .Values.aws.secretmanager.enabled .Values.secret.aws.nexusSecret.enabled) (and .Values.azure.keyvault.enabled .Values.secret.azure.nexusSecret.enabled ) }}
               value: /nxrm-secrets/{{ .Values.secret.nexusSecret.name }}
@@ -177,19 +177,21 @@ spec:
             {{ toYaml .Values.statefulset.container.additionalEnv | nindent 12 }}
           {{- end }}
           volumeMounts:
-          {{- if or .Values.aws.secretmanager.enabled .Values.azure.keyvault.enabled .Values.secret.dbSecret.enabled }}
+          {{- if or .Values.aws.secretmanager.enabled .Values.azure.keyvault.enabled .Values.secret.dbSecret.enabled .Values.externalsecrets.enabled }}
             - name: nxrm-secrets
               mountPath: /nxrm-secrets
           {{- end }}
-          {{- if .Values.secret.license.licenseSecret.enabled }}
+          {{- if or .Values.secret.license.licenseSecret.enabled .Values.externalsecrets.enabled }}
             - name: license-volume
               mountPath: {{ .Values.secret.license.licenseSecret.mountPath }}
               readOnly: true
           {{ end }}
-          {{- if and .Values.secret.nexusSecret.enabled (not .Values.secret.aws.nexusSecret.enabled) (not .Values.secret.azure.nexusSecret.enabled) }}
+          {{-  if or ( .Values.secret.nexusSecret.enabled ) (and .Values.externalsecrets.enabled .Values.externalsecrets.secrets.nexusSecret.enabled ) }}
+          {{- if and (not .Values.secret.aws.nexusSecret.enabled) (not .Values.secret.azure.nexusSecret.enabled) }}
             - name: nexus-secret-volume
               mountPath: {{ .Values.secret.nexusSecret.mountPath }}
               readOnly: true
+          {{ end }}
           {{ end }}
             - name: nexus-data
               mountPath: /nexus-data
@@ -258,7 +260,7 @@ spec:
       {{- if .Values.statefulset.additionalVolumes }}
         {{ toYaml .Values.statefulset.additionalVolumes | nindent 8 }}
       {{- end }}
-      {{- if or .Values.aws.secretmanager.enabled .Values.azure.keyvault.enabled .Values.secret.dbSecret.enabled }}
+      {{- if or .Values.aws.secretmanager.enabled .Values.azure.keyvault.enabled .Values.secret.dbSecret.enabled .Values.externalsecrets.enabled }}
         - name: nxrm-secrets
         {{- if or .Values.aws.secretmanager.enabled .Values.azure.keyvault.enabled }}
           csi:
@@ -272,15 +274,17 @@ spec:
             secretName: {{ template "nexus.name" . }}-dbsecret
         {{ end }}
       {{ end }}
-      {{- if .Values.secret.license.licenseSecret.enabled }}
+      {{- if or .Values.secret.license.licenseSecret.enabled .Values.externalsecrets.enabled }}
         - name: license-volume
           secret:
             secretName: {{ .Values.secret.license.name }}
       {{ end }}
-      {{- if and .Values.secret.nexusSecret.enabled (not .Values.secret.aws.nexusSecret.enabled ) (not .Values.secret.azure.nexusSecret.enabled) }}
+      {{- if or (.Values.secret.nexusSecret.enabled) (and .Values.externalsecrets.enabled .Values.externalsecrets.secrets.nexusSecret.enabled) }}
+        {{- if and (not .Values.secret.aws.nexusSecret.enabled) (not .Values.secret.azure.nexusSecret.enabled) }}
         - name: nexus-secret-volume
           secret:
             secretName: {{ .Values.secret.nexusSecret.name }}
+        {{ end }}
       {{ end }}
       {{- if .Values.logStorage.combineTaskLogs }}
         - name: logback-tasklogfile-override

--- a/nxrm-ha/tests/database-secret_test.yaml
+++ b/nxrm-ha/tests/database-secret_test.yaml
@@ -8,7 +8,7 @@ chart:
   version: "latest"
   appVersion: "latest"
 tests:
-  - it: should create db secret when secret.dbSecret.enabled is true and aws.secretmanager.enabled and azure.keyvault.enabled are false
+  - it: should create db secret only when secret.dbSecret.enabled is true
     set:
       secret:
         dbSecret:
@@ -57,7 +57,6 @@ tests:
               helm.sh/chart: nxrm-ha-latest
               foo: bar
               baz: bay
-
   - it: should create db secret in release namespace when secret.dbSecret.enabled is true, and aws.secretmanager.enabled and azure.keyvault.enabled are false, and nexusNs.name is empty
     set:
       namespaces:
@@ -76,3 +75,30 @@ tests:
       - equal:
           path: metadata.namespace
           value: "test-namespace"
+
+  - it: should not create db secret when aws.secretmanager.enabled is true
+    set:
+      aws:
+        secretmanager:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create db secret when azure.keyvault.enabled is true
+    set:
+      azure:
+        keyvault:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create db secret when externalsecrets.enabled is true
+    set:
+      azure:
+        keyvault:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/nxrm-ha/tests/eso-admin-secrets_test.yaml
+++ b/nxrm-ha/tests/eso-admin-secrets_test.yaml
@@ -1,0 +1,73 @@
+suite: test external secrets operator admin secret
+templates:
+  - eso-admin-secrets.yaml
+release:
+  name: "test-release"
+chart:
+  version: "latest"
+  appVersion: "latest"
+tests:
+  - it: should create admin secret when externalsecrets.enabled is true and aws.secretmanager.enabled and azure.keyvault.enabled are false
+    set:
+      externalsecrets:
+        enabled: true
+        secrets:
+          admin:
+            refreshInterval: 1h
+            valueIsJson: true
+            providerSecretName: adminSecretName # The name of the AWS SecretsManager/Azure KeyVault etc secret
+            adminPasswordKey: "nexusAdminPassword" # the name of the key in the secret which contains your nexus repository admin password
+      nexus:
+        extraLabels:
+          foo: bar
+          baz: bay
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: metadata.name
+          value: "nxrm-ha-external-adminsecret"
+      - equal:
+          path: metadata.namespace
+          value: "nexusrepo"
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
+      - equal:
+          path: spec.secretStoreRef.kind
+          value: SecretStore
+
+      - equal:
+          path: spec.secretStoreRef.name
+          value: nxrm-ha-nexus-secret-store
+
+      - equal:
+          path: spec.target.name
+          value: nxrm-ha-adminsecret
+
+      - equal:
+          path: spec.target.creationPolicy
+          value: Owner
+
+      - equal:
+          path: spec.data[0].secretKey
+          value: nexus-admin-password
+
+      - equal:
+          path: spec.data[0].remoteRef.key
+          value: adminSecretName
+
+      - equal:
+          path: spec.data[0].remoteRef.property
+          value: nexusAdminPassword
+
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: test-release
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: nxrm-ha
+            app.kubernetes.io/version: latest
+            helm.sh/chart: nxrm-ha-latest
+            foo: bar
+            baz: bay

--- a/nxrm-ha/tests/eso-database-secrets_test.yaml
+++ b/nxrm-ha/tests/eso-database-secrets_test.yaml
@@ -1,0 +1,100 @@
+suite: test external secrets operator database secret
+templates:
+  - eso-database-secrets.yaml
+release:
+  name: "test-release"
+chart:
+  version: "latest"
+  appVersion: "latest"
+tests:
+  - it: should create database secret when externalsecrets.enabled is true and aws.secretmanager.enabled and azure.keyvault.enabled are false
+    set:
+      externalsecrets:
+        enabled: true
+        secrets:
+          database:
+            refreshInterval: 1h
+            valueIsJson: true
+            providerSecretName: dbSecretName
+            dbUserKey: username
+            dbPasswordKey: password
+            dbHostKey: host
+      nexus:
+        extraLabels:
+          foo: bar
+          baz: bay
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: metadata.name
+          value: "nxrm-ha-external-dbsecret"
+      - equal:
+          path: metadata.namespace
+          value: "nexusrepo"
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
+      - equal:
+          path: spec.secretStoreRef.kind
+          value: SecretStore
+
+      - equal:
+          path: spec.secretStoreRef.name
+          value: nxrm-ha-nexus-secret-store
+
+      - equal:
+          path: spec.target.name
+          value: nxrm-ha-dbsecret
+
+
+      - equal:
+          path: spec.target.creationPolicy
+          value: Owner
+
+      - equal:
+          path: spec.data[0].secretKey
+          value: db-user
+
+      - equal:
+          path: spec.data[0].remoteRef.key
+          value: dbSecretName
+
+      - equal:
+          path: spec.data[0].remoteRef.property
+          value: username
+
+      - equal:
+          path: spec.data[1].secretKey
+          value: db-password
+
+      - equal:
+          path: spec.data[1].remoteRef.key
+          value: dbSecretName
+
+      - equal:
+          path: spec.data[1].remoteRef.property
+          value: password
+
+      - equal:
+          path: spec.data[2].secretKey
+          value: db-host
+
+      - equal:
+          path: spec.data[2].remoteRef.key
+          value: dbSecretName
+
+      - equal:
+          path: spec.data[2].remoteRef.property
+          value: host
+
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: test-release
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: nxrm-ha
+            app.kubernetes.io/version: latest
+            helm.sh/chart: nxrm-ha-latest
+            foo: bar
+            baz: bay

--- a/nxrm-ha/tests/eso-license-secrets_test.yaml
+++ b/nxrm-ha/tests/eso-license-secrets_test.yaml
@@ -1,0 +1,70 @@
+suite: test external secrets operator license secret
+templates:
+  - eso-license-secrets.yaml
+release:
+  name: "test-release"
+chart:
+  version: "latest"
+  appVersion: "latest"
+tests:
+  - it: should create license secret when externalsecrets.enabled is true and aws.secretmanager.enabled and azure.keyvault.enabled are false
+    set:
+      externalsecrets:
+        enabled: true
+        secrets:
+          license:
+            decodingStrategy: Base64
+      nexus:
+        extraLabels:
+          foo: bar
+          baz: bay
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: metadata.name
+          value: "nxrm-ha-external-nexus-repo-license.lic"
+      - equal:
+          path: metadata.namespace
+          value: "nexusrepo"
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
+      - equal:
+          path: spec.secretStoreRef.kind
+          value: SecretStore
+
+      - equal:
+          path: spec.secretStoreRef.name
+          value: nxrm-ha-nexus-secret-store
+
+      - equal:
+          path: spec.target.name
+          value: nexus-repo-license.lic
+
+      - equal:
+          path: spec.target.creationPolicy
+          value: Owner
+
+      - equal:
+          path: spec.data[0].secretKey
+          value: nexus-repo-license.lic
+
+      - equal:
+          path: spec.data[0].remoteRef.key
+          value: nexus-repo-license.lic
+
+      - equal:
+          path: spec.data[0].remoteRef.decodingStrategy
+          value: Base64
+
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: test-release
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: nxrm-ha
+            app.kubernetes.io/version: latest
+            helm.sh/chart: nxrm-ha-latest
+            foo: bar
+            baz: bay

--- a/nxrm-ha/tests/eso-nexus-secrets_test.yaml
+++ b/nxrm-ha/tests/eso-nexus-secrets_test.yaml
@@ -1,0 +1,71 @@
+suite: test external secrets operator nexus secret
+templates:
+  - eso-nexus-secrets.yaml
+release:
+  name: "test-release"
+chart:
+  version: "latest"
+  appVersion: "latest"
+tests:
+  - it: should create nexus secret when externalsecrets.enabled and externalsecrets.secrets.nexusSecret.enabled are true
+    set:
+      externalsecrets:
+        enabled: true
+        secrets:
+          nexusSecret:
+            enabled: true
+            decodingStrategy: Base64
+      nexus:
+        extraLabels:
+          foo: bar
+          baz: bay
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: metadata.name
+          value: "nxrm-ha-external-nexus-secret.json"
+      - equal:
+          path: metadata.namespace
+          value: "nexusrepo"
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
+      - equal:
+          path: spec.secretStoreRef.kind
+          value: SecretStore
+
+      - equal:
+          path: spec.secretStoreRef.name
+          value: nxrm-ha-nexus-secret-store
+
+      - equal:
+          path: spec.target.name
+          value: nexus-secret.json
+
+      - equal:
+          path: spec.target.creationPolicy
+          value: Owner
+
+      - equal:
+          path: spec.data[0].secretKey
+          value: nexus-secret.json
+
+      - equal:
+          path: spec.data[0].remoteRef.key
+          value: nexus-secret.json
+
+      - equal:
+          path: spec.data[0].remoteRef.decodingStrategy
+          value: Base64
+
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: test-release
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: nxrm-ha
+            app.kubernetes.io/version: latest
+            helm.sh/chart: nxrm-ha-latest
+            foo: bar
+            baz: bay

--- a/nxrm-ha/tests/eso-secret-store_test.yaml
+++ b/nxrm-ha/tests/eso-secret-store_test.yaml
@@ -1,0 +1,57 @@
+suite: test external secrets operator secret store
+templates:
+  - eso-secret-store.yaml
+release:
+  name: "test-release"
+chart:
+  version: "latest"
+  appVersion: "latest"
+tests:
+  - it: should create secret store when externalsecrets.enabled is true and aws.secretmanager.enabled and azure.keyvault.enabled are false
+    set:
+      externalsecrets:
+        enabled: true
+        secretstore:
+          spec:
+            provider:
+              aws:
+                service: SecretsManager
+                region: us-east-1
+                auth:
+                  jwt:
+                    serviceAccountRef:
+                      name: nexus-repository-deployment-sa # use same service account name as specified in serviceAccount.name
+      nexus:
+        extraLabels:
+          foo: bar
+          baz: bay
+    asserts:
+      - isKind:
+          of: SecretStore
+      - equal:
+          path: metadata.name
+          value: "nxrm-ha-nexus-secret-store"
+      - equal:
+          path: metadata.namespace
+          value: "nexusrepo"
+      - equal:
+          path: spec.provider
+          value:
+            aws:
+              service: SecretsManager
+              region: us-east-1
+              auth:
+                jwt:
+                  serviceAccountRef:
+                    name: nexus-repository-deployment-sa
+
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/instance: test-release
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: nxrm-ha
+            app.kubernetes.io/version: latest
+            helm.sh/chart: nxrm-ha-latest
+            foo: bar
+            baz: bay

--- a/nxrm-ha/tests/license-config-mapping_test.yaml
+++ b/nxrm-ha/tests/license-config-mapping_test.yaml
@@ -8,7 +8,7 @@ chart:
   version: "latest"
   appVersion: "latest"
 tests:
-  - it: should create license secret
+  - it: should create license secret when license.licenseSecret.enabled is true
     set:
       secret:
         license:
@@ -58,3 +58,28 @@ tests:
       - equal:
           path: metadata.namespace
           value: "test-namespace"
+  - it: should be empty doc when azure.keyvault.enabled is true
+    set:
+      azure:
+        keyvault:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be empty doc when aws.secretmanager.enabled is true
+    set:
+      aws:
+        secretmanager:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should be empty doc when externalsecrets.enabled is true
+    set:
+      externalsecrets:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/nxrm-ha/values.yaml
+++ b/nxrm-ha/values.yaml
@@ -10,6 +10,7 @@ namespaces:
 serviceAccount:
   enabled: false
   name: nexus-repository-deployment-sa #This service account in managed by Helm
+  labels: {}
   annotations:
     # Set annotations for service account. E.g. if deploying to AWS EKS
     # and secrets manager is enabled then this role should have permissions for using secret manager.
@@ -33,6 +34,8 @@ aws:
     fluentBitVersion: 2.28.0
     clusterName: nxrm-nexus
 statefulset:
+  name: nxrm-statefulset
+  serviceName: nxrm-statefulset-service
   replicaCount: 3
   clustered: true
   additionalVolumes:
@@ -216,6 +219,49 @@ service:  #Nexus Repo NodePort Service
   headless:
     annotations: {}
     publishNotReadyAddresses: true # We want all pods in the StatefulSet to have their addresses published even before they're ready.
+externalsecrets:
+  enabled: false
+  secretstore:
+    name: nexus-secret-store
+    spec:
+      provider:
+#        aws:
+#          service: SecretsManager
+#          region: us-east-1
+#          auth:
+#            jwt:
+#              serviceAccountRef:
+#                name: nexus-repository-deployment-sa # Use the same service account name as specified in serviceAccount.name
+# Example for Azure
+#    spec:
+#      provider:
+#        azurekv:
+#          authType: WorkloadIdentity
+#          vaultUrl: "https://xx-xxxx-xx.vault.azure.net"
+#          serviceAccountRef:
+#            name: nexus-repository-deployment-sa # Use the same service account name as specified in serviceAccount.name
+  secrets:
+    nexusSecret:
+      enabled: false
+      refreshInterval: 1h
+      providerSecretName: nexus-secret.json
+      decodingStrategy: null # For Azure set to Base64
+    database:
+      refreshInterval: 1h
+      valueIsJson: false
+      providerSecretName: dbSecretName # The name of the AWS SecretsManager/Azure KeyVault/etc. secret
+      dbUserKey: username #  The name of the key in the secret that contains your database username
+      dbPasswordKey: password # The name of the key in the secret that contains your database password
+      dbHostKey: host # The name of the key in the secret that contains your database host
+    admin:
+      refreshInterval: 1h
+      valueIsJson: false
+      providerSecretName: adminSecretName # The name of the AWS SecretsManager/Azure KeyVault/etc. secret
+      adminPasswordKey: "nexusAdminPassword" # The name of the key in the secret that contains your nexus repository admin password
+    license:
+      providerSecretName: nexus-repo-license.lic # The name of the AWS SecretsManager/Azure KeyVault/etc. secret that contains your Nexus Repository license
+      decodingStrategy: null # Can be Base64
+      refreshInterval: 1h
 secret:
   secretProviderClass: "secretProviderClass"
   provider: provider # e.g. aws, azure etc


### PR DESCRIPTION
Allows secrets to be transparently synced from external secret providers such as AWS Secrets Manager, Azure Key Vault, Hashicorp Vault etc see [full list of providers](https://external-secrets.io/latest/provider/aws-secrets-manager/) )to Kubernetes secrets using the [external-secret operator](https://external-secrets.io/latest/)