### PR TITLE
Fix nexus docker tag test

### DIFF
--- a/nxrm-ha/tests/statefulset_test.yaml
+++ b/nxrm-ha/tests/statefulset_test.yaml
@@ -624,7 +624,7 @@ tests:
 
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "^sonatype/nexus3:latest"
+          pattern: "^sonatype/nexus3:\\d\\.\\d{2}\\.\\d|latest"
 
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsUser


### PR DESCRIPTION
**CI** [Helm chart](https://jenkins.ci.sonatype.dev/job/nxrm/job/Nexus%20Repository%20Manager%203%20HA%20Helm3%20Charts/job/Feature%20Snapshot%20Builds/job/fix_nexus_docker_tag_test/) ✅ 

**Description**
The test failed on the release Jenkins job since `./upgrade.sh` will change the tag from `latest` to `x.yy.z`