### PR TITLE
support setting pod security context

### DIFF
--- a/nxrm-ha/templates/statefulset.yaml
+++ b/nxrm-ha/templates/statefulset.yaml
@@ -66,6 +66,10 @@ spec:
       imagePullSecrets:
         - name: {{ template "nexus.name" . }}-imagepullsecret
       {{- end }}
+      {{- if .Values.statefulset.securityContext }}
+      securityContext:
+        {{ toYaml .Values.statefulset.securityContext | nindent 8 }}
+      {{- end }}
       containers:
         - name: nxrm-app
           image: {{ .Values.statefulset.container.image.repository }}:{{ .Values.statefulset.container.image.nexusTag }}


### PR DESCRIPTION
this is required in order to set e.g. `fsGroup`