### PR TITLE
Add the ability to run the OSS version

### DIFF
--- a/nxrm-ha/templates/statefulset.yaml
+++ b/nxrm-ha/templates/statefulset.yaml
@@ -151,8 +151,14 @@ spec:
           -Dnexus.datastore.nexus.jdbcUrl=jdbc:postgresql://${DB_HOST}:{{ .Values.statefulset.container.env.nexusDBPort }}/${DB_NAME}{{ .Values.statefulset.container.env.jdbcUrlParams }} \
           -Dnexus.datastore.nexus.username=${DB_USER} \
           -Dnexus.datastore.nexus.password=${DB_PASSWORD}"
-          {{ else }}
+          {{ else if .Values.secret.license.enabled }}
               value: "{{ .Values.statefulset.container.env.install4jAddVmParams }} -Dnexus.licenseFile=${LICENSE_FILE} \
+              -Dnexus.datastore.enabled=true -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs \
+              -Dnexus.datastore.nexus.jdbcUrl=jdbc:postgresql://${DB_HOST}:{{ .Values.statefulset.container.env.nexusDBPort }}/${DB_NAME}{{ .Values.statefulset.container.env.jdbcUrlParams }} \
+              -Dnexus.datastore.nexus.username=${DB_USER} \
+              -Dnexus.datastore.nexus.password=${DB_PASSWORD}"
+          {{ else }}
+              value: "{{ .Values.statefulset.container.env.install4jAddVmParams }} \
               -Dnexus.datastore.enabled=true -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs \
               -Dnexus.datastore.nexus.jdbcUrl=jdbc:postgresql://${DB_HOST}:{{ .Values.statefulset.container.env.nexusDBPort }}/${DB_NAME}{{ .Values.statefulset.container.env.jdbcUrlParams }} \
               -Dnexus.datastore.nexus.username=${DB_USER} \

--- a/nxrm-ha/templates/statefulset.yaml
+++ b/nxrm-ha/templates/statefulset.yaml
@@ -158,7 +158,7 @@ spec:
               -Dnexus.datastore.nexus.username=${DB_USER} \
               -Dnexus.datastore.nexus.password=${DB_PASSWORD}"
           {{ else }}
-              value: "{{ .Values.statefulset.container.env.install4jAddVmParams }} \
+              value: "{{ .Values.statefulset.container.env.install4jAddVmParams }} -Dnexus.loadAsOSS=true \
               -Dnexus.datastore.enabled=true -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs \
               -Dnexus.datastore.nexus.jdbcUrl=jdbc:postgresql://${DB_HOST}:{{ .Values.statefulset.container.env.nexusDBPort }}/${DB_NAME}{{ .Values.statefulset.container.env.jdbcUrlParams }} \
               -Dnexus.datastore.nexus.username=${DB_USER} \

--- a/nxrm-ha/values.yaml
+++ b/nxrm-ha/values.yaml
@@ -188,7 +188,7 @@ secret:
     enabled: false # Enable to apply nexus-admin-secret.yaml which allows you to the initial admin password for nexus repository
     adminPassword: yourinitialnexuspassword #You should change this when you login for the first time
   license:
-    enabled: true
+    enabled: true # Disable to start OSS version
     name: nexus-repo-license.lic
     licenseSecret:
       enabled: false

--- a/nxrm-ha/values.yaml
+++ b/nxrm-ha/values.yaml
@@ -188,6 +188,7 @@ secret:
     enabled: false # Enable to apply nexus-admin-secret.yaml which allows you to the initial admin password for nexus repository
     adminPassword: yourinitialnexuspassword #You should change this when you login for the first time
   license:
+    enabled: true
     name: nexus-repo-license.lic
     licenseSecret:
       enabled: false


### PR DESCRIPTION
At this moment it is not possible to run OSS version of Nexus using this chart. This is described in issue #70 

It can be fixed by adding `.Values.secret.license.enabled` to values.yaml which allows to place `-Dnexus.loadAsOSS=true` option instead of providing licence file (`-Dnexus.licenseFile=${LICENSE_FILE}`).