### PR TITLE
Support setting Topology Spread Constraints

### DIFF
--- a/nxrm-ha/templates/statefulset.yaml
+++ b/nxrm-ha/templates/statefulset.yaml
@@ -62,6 +62,10 @@ spec:
       nodeSelector:
         {{ toYaml .Values.statefulset.nodeSelector | nindent 8 }}
       {{- end }}
+      {{- if .Values.statefulset.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ toYaml .Values.statefulset.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
       {{- if .Values.statefulset.hostAliases }}
       hostAliases:
         {{ toYaml .Values.statefulset.hostAliases | nindent 8 }}

--- a/nxrm-ha/values.yaml
+++ b/nxrm-ha/values.yaml
@@ -42,6 +42,7 @@ statefulset:
   annotations: {}
   podAnnotations: {}
   nodeSelector: {}
+  topologySpreadConstraints: {}
   # hostAliases allows the modification of the hosts file inside a container
   hostAliases: []
   # - ip: "192.168.1.10"

--- a/nxrm-ha/values.yaml
+++ b/nxrm-ha/values.yaml
@@ -42,7 +42,7 @@ statefulset:
   annotations: {}
   podAnnotations: {}
   nodeSelector: {}
-  topologySpreadConstraints: {}
+  topologySpreadConstraints: []
   # hostAliases allows the modification of the hosts file inside a container
   hostAliases: []
   # - ip: "192.168.1.10"


### PR DESCRIPTION
Desired for ensuring Nexus High Availability pods run in different availability zones for redundancy and lower latency.

Implements issue #75  