### PR TITLE
Add the option to use existing secrets for DB, imagePullSecrets and license file, fixes #61

### DIFF
--- a/nxrm-ha/Chart.yaml
+++ b/nxrm-ha/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 72.0.1
+version: 74.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 3.72.0
+appVersion: 3.74.0
 
 keywords:
   - artifacts

--- a/nxrm-ha/Chart.yaml
+++ b/nxrm-ha/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 72.0.0
+version: 72.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -38,4 +38,3 @@ home: https://www.sonatype.com/products/sonatype-nexus-repository
 icon: https://sonatype.github.io/helm3-charts/NexusRepo_Vertical.svg
 maintainers:
   - name: Sonatype
-

--- a/nxrm-ha/templates/image-pull-secret.yaml
+++ b/nxrm-ha/templates/image-pull-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.statefulset.imagePullSecrets }}
+{{- if and .Values.statefulset.imagePullSecrets.secret (not .Values.statefulset.imagePullSecrets.existingSecret.enabled) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/nxrm-ha/templates/statefulset.yaml
+++ b/nxrm-ha/templates/statefulset.yaml
@@ -121,6 +121,28 @@ spec:
             timeoutSeconds: {{ .Values.statefulset.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.statefulset.readinessProbe.failureThreshold }}
           env:
+          {{- if and .Values.secret.existingDbSecret.enabled (not .Values.secret.dbSecret.enabled) (not .Values.aws.secretmanager.enabled) (not .Values.azure.keyvault.enabled) }}
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secret.existingDbSecret.name }}
+                  key: {{ .Values.secret.existingDbSecret.dbNameKey }}
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secret.existingDbSecret.name }}
+                  key: {{ .Values.secret.existingDbSecret.dbHostKey }}
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secret.existingDbSecret.name }}
+                  key: {{ .Values.secret.existingDbSecret.dbUserKey }}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secret.existingDbSecret.name }}
+                  key: {{ .Values.secret.existingDbSecret.dbPassKey }}
+          {{- else }}
             - name: DB_NAME
               value: "{{ .Values.statefulset.container.env.nexusDBName }}"
             - name: DB_PASSWORD
@@ -138,6 +160,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "nexus.name" . }}-dbsecret
                   key: db-host
+          {{ end }}
             - name: NEXUS_SECURITY_INITIAL_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/nxrm-ha/templates/statefulset.yaml
+++ b/nxrm-ha/templates/statefulset.yaml
@@ -121,28 +121,7 @@ spec:
             timeoutSeconds: {{ .Values.statefulset.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.statefulset.readinessProbe.failureThreshold }}
           env:
-          {{- if and .Values.secret.existingDbSecret.enabled (not .Values.secret.dbSecret.enabled) (not .Values.aws.secretmanager.enabled) (not .Values.azure.keyvault.enabled) }}
-            - name: DB_NAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.secret.existingDbSecret.name }}
-                  key: {{ .Values.secret.existingDbSecret.dbNameKey }}
-            - name: DB_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.secret.existingDbSecret.name }}
-                  key: {{ .Values.secret.existingDbSecret.dbHostKey }}
-            - name: DB_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.secret.existingDbSecret.name }}
-                  key: {{ .Values.secret.existingDbSecret.dbUserKey }}
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.secret.existingDbSecret.name }}
-                  key: {{ .Values.secret.existingDbSecret.dbPassKey }}
-          {{- else }}
+          {{- if (not .Values.secret.existingDbSecret.enabled) }}
             - name: DB_NAME
               value: "{{ .Values.statefulset.container.env.nexusDBName }}"
             - name: DB_PASSWORD

--- a/nxrm-ha/templates/statefulset.yaml
+++ b/nxrm-ha/templates/statefulset.yaml
@@ -199,7 +199,7 @@ spec:
             - name: nxrm-secrets
               mountPath: /nxrm-secrets
           {{- end }}
-          {{- if .Values.secret.license.licenseSecret.enabled }}
+          {{- if or .Values.secret.license.licenseSecret.enabled .Values.secret.license.existingSecret }}
             - name: license-volume
               mountPath: {{ .Values.secret.license.licenseSecret.mountPath }}
               readOnly: true
@@ -285,7 +285,7 @@ spec:
             secretName: {{ template "nexus.name" . }}-dbsecret
         {{ end }}
       {{ end }}
-      {{- if .Values.secret.license.licenseSecret.enabled }}
+      {{- if or .Values.secret.license.licenseSecret.enabled .Values.secret.license.existingSecret }}
         - name: license-volume
           secret:
             secretName: {{ .Values.secret.license.name }}

--- a/nxrm-ha/templates/statefulset.yaml
+++ b/nxrm-ha/templates/statefulset.yaml
@@ -66,9 +66,12 @@ spec:
       hostAliases:
         {{ toYaml .Values.statefulset.hostAliases | nindent 8 }}
       {{- end }}
-      {{- if .Values.statefulset.imagePullSecrets }}
+      {{- if and .Values.statefulset.imagePullSecrets.secret (not .Values.statefulset.imagePullSecrets.existingSecret.enabled) }}
       imagePullSecrets:
         - name: {{ template "nexus.name" . }}-imagepullsecret
+      {{- else if and (not .Values.statefulset.imagePullSecrets.secret) .Values.statefulset.imagePullSecrets.existingSecret.enabled .Values.statefulset.imagePullSecrets.existingSecret.name }}
+      imagePullSecrets:
+        - name: {{ .Values.statefulset.imagePullSecrets.existingSecret.name }}
       {{- end }}
       containers:
         - name: nxrm-app

--- a/nxrm-ha/values.yaml
+++ b/nxrm-ha/values.yaml
@@ -16,20 +16,20 @@ serviceAccount:
     # If using externaldns, role with route53 permissions needed by external-dns
     # eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/nxrm-nexus-role
 azure:
-  enabled: false #set to true to enable azure specific yamls/snippets
+  enabled: false # set to true to enable azure specific yamls/snippets
   keyvault:
     enabled: false # set to true to pull license, db and nexus admin password secrets from azure key vault
 aws:
-  enabled: false #set to true to enable aws specific yamls like external dns and fluent bit
+  enabled: false # set to true to enable aws specific yamls like external dns and fluent bit
   clusterRegion: us-east-1
   secretmanager:
     enabled: false # set to true to pull license, db and nexus admin password secrets from aws secret manager
   externaldns:
     enabled: false
-    domainFilter: example.com #your root domain e.g example.com
+    domainFilter: example.com # your root domain e.g example.com
     awsZoneType: private # hosted zone to look at (valid values are public, private or no value for both)
   fluentbit:
-    enabled: false #set this to true to enable sending of logs to CloudWatch
+    enabled: false # set this to true to enable sending of logs to CloudWatch
     fluentBitVersion: 2.28.0
     clusterName: nxrm-nexus
 statefulset:

--- a/nxrm-ha/values.yaml
+++ b/nxrm-ha/values.yaml
@@ -259,6 +259,8 @@ secret:
     adminPassword: yourinitialnexuspassword #You should change this when you login for the first time
   license:
     name: nexus-repo-license.lic
+    # -- Use an already created secret with the license contents in base64, it takes the name from the above field -> name: nexus-repo-license.lic and the mount path from below: licenseSecret.mountPath
+    existingSecret: false
     licenseSecret:
       enabled: false
       file: # Specify the license file name with --set-file license.licenseSecret.file="file_name" helm option

--- a/nxrm-ha/values.yaml
+++ b/nxrm-ha/values.yaml
@@ -16,7 +16,7 @@ serviceAccount:
     # If using externaldns, role with route53 permissions needed by external-dns
     # eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/nxrm-nexus-role
 azure:
-  enabled: false  #set to true to enable azure specific yamls/snippets
+  enabled: false #set to true to enable azure specific yamls/snippets
   keyvault:
     enabled: false # set to true to pull license, db and nexus admin password secrets from azure key vault
 aws:
@@ -51,7 +51,7 @@ statefulset:
 
   # Uncomment and modify this to run a command after starting the nexus container.
   postStart:
-    command: null   # '["/bin/sh", "-c", "ls"]'
+    command: null # '["/bin/sh", "-c", "ls"]'
   preStart:
     command: null
 
@@ -158,7 +158,15 @@ statefulset:
     timeoutSeconds: 1
     failureThreshold: 6
     path: /
-  imagePullSecrets: {}
+  imagePullSecrets:
+    # -- The base64 encoded dockerconfigjson
+    secret: ""
+    # -- Use an existing imagePullSecret created by a secrets operator
+    existingSecret:
+      # -- By default the existing secret is disabled, set this to true in order to provide an existing imagePullSecret
+      enabled: false
+      # -- The existing imagePullSecret name
+      name: ""
 ingress:
   name: "nexus-ingress"
   enabled: false
@@ -168,22 +176,22 @@ ingress:
   defaultRule: false
   additionalRules: null
   ingressClassName: null # e.g. nginx, alb
-#  tls:
-#    - secretName: "tlsSecretName1"
-#      hosts:
-#      - repo.foo1
-#      - repo.bar1
-#    - secretName: "tlsSecretName2"
-#      hosts:
-#        - repo.foo2
-#        - repo.bar2
+  #  tls:
+  #    - secretName: "tlsSecretName1"
+  #      hosts:
+  #      - repo.foo1
+  #      - repo.bar1
+  #    - secretName: "tlsSecretName2"
+  #      hosts:
+  #        - repo.foo2
+  #        - repo.bar2
   annotations:
 #  Note: the annotations below are just a guide; delete or insert more as needed depending on your use case: aws, azure, on prem
 #    nginx.ingress.kubernetes.io/ssl-redirect: "false"
 #    alb.ingress.kubernetes.io/scheme: internal # scheme
 #    alb.ingress.kubernetes.io/subnets: subnet-1,subnet-2 #comma separated list of subnet ids
-    # alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
-    # alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:0000000000000:certificate/00000000-1111-2222-3333-444444444444  # The AWS Certificate Manager ARN for your HTTPS certificate
+# alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+# alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:0000000000000:certificate/00000000-1111-2222-3333-444444444444  # The AWS Certificate Manager ARN for your HTTPS certificate
 #    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:0000000000000:certificate/00000000-1111-2222-3333-444444444444  # Comment out if you don't use docker repositories - The AWS Certificate Manager ARN for your HTTPS certificate
 #    external-dns.alpha.kubernetes.io/hostname: dockerrepo1.example.com, dockerrepo2.example.com, dockerrepo3.example.com
 logStorage:
@@ -206,7 +214,7 @@ pvc:
     enabled: false
   existingClaim: null
 
-service:  #Nexus Repo NodePort Service
+service: #Nexus Repo NodePort Service
   annotations: {}
   nexus:
     enabled: false

--- a/nxrm-ha/values.yaml
+++ b/nxrm-ha/values.yaml
@@ -237,6 +237,20 @@ secret:
     passwordAlias: nxrm_db_password_alias
     host: nxrm_db_host
     hostAlias: nxrm_db_host_alias
+  # -- Use an existing secret for the database variables: DB_NAME, DB_HOST, DB_USER, DB_PASSWORD
+  existingDbSecret:
+    # -- Enabled the use of the already created secret
+    enabled: false
+    # -- The name of the preexisting secret that contains the values for the env variables: DB_NAME, DB_HOST, DB_USER, DB_PASSWORD
+    name: ""
+    # -- The name of the key specifying the database name
+    dbNameKey: ""
+    # -- The name of the key specifying the database host
+    dbHostKey: ""
+    # -- The name of the key specifying the database user
+    dbUserKey: ""
+    # -- The name of the key specifying the database password
+    dbPassKey: ""
   nexusAdmin:
     name: "nexusAdminPassword"
     alias: "admin-nxrm-password-alias"

--- a/nxrm-ha/values.yaml
+++ b/nxrm-ha/values.yaml
@@ -106,7 +106,29 @@ statefulset:
       jdbcUrlParams: null # Must start with a '?' e.g. "?foo=bar&baz=foo"
       zeroDowntimeEnabled: false
 
-    additionalEnv: null
+    additionalEnv:
+      null
+      # -- Uncomment these when using secret.existingDbSecret.enabled = true
+      # - name: DB_NAME
+      #   valueFrom:
+      #     secretKeyRef:
+      #       name: secret-name
+      #       key: secret-key
+      # - name: DB_HOST
+      #   valueFrom:
+      #     secretKeyRef:
+      #       name: secret-name
+      #       key: secret-key
+      # - name: DB_USER
+      #   valueFrom:
+      #     secretKeyRef:
+      #       name: secret-name
+      #       key: secret-key
+      # - name: DB_PASSWORD
+      #   valueFrom:
+      #     secretKeyRef:
+      #       name: secret-name
+      #       key: secret-key
   requestLogContainer:
     image:
       repository: busybox
@@ -239,18 +261,8 @@ secret:
     hostAlias: nxrm_db_host_alias
   # -- Use an existing secret for the database variables: DB_NAME, DB_HOST, DB_USER, DB_PASSWORD
   existingDbSecret:
-    # -- Enabled the use of the already created secret
+    # -- Enabled the use of an already created secret, you need to uncomment the values from additionalEnv
     enabled: false
-    # -- The name of the preexisting secret that contains the values for the env variables: DB_NAME, DB_HOST, DB_USER, DB_PASSWORD
-    name: ""
-    # -- The name of the key specifying the database name
-    dbNameKey: ""
-    # -- The name of the key specifying the database host
-    dbHostKey: ""
-    # -- The name of the key specifying the database user
-    dbUserKey: ""
-    # -- The name of the key specifying the database password
-    dbPassKey: ""
   nexusAdmin:
     name: "nexusAdminPassword"
     alias: "admin-nxrm-password-alias"

--- a/nxrm-ha/values.yaml
+++ b/nxrm-ha/values.yaml
@@ -212,8 +212,8 @@ ingress:
 #    nginx.ingress.kubernetes.io/ssl-redirect: "false"
 #    alb.ingress.kubernetes.io/scheme: internal # scheme
 #    alb.ingress.kubernetes.io/subnets: subnet-1,subnet-2 #comma separated list of subnet ids
-# alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
-# alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:0000000000000:certificate/00000000-1111-2222-3333-444444444444  # The AWS Certificate Manager ARN for your HTTPS certificate
+#    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+#    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:0000000000000:certificate/00000000-1111-2222-3333-444444444444  # The AWS Certificate Manager ARN for your HTTPS certificate
 #    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:0000000000000:certificate/00000000-1111-2222-3333-444444444444  # Comment out if you don't use docker repositories - The AWS Certificate Manager ARN for your HTTPS certificate
 #    external-dns.alpha.kubernetes.io/hostname: dockerrepo1.example.com, dockerrepo2.example.com, dockerrepo3.example.com
 logStorage:
@@ -236,7 +236,7 @@ pvc:
     enabled: false
   existingClaim: null
 
-service: #Nexus Repo NodePort Service
+service: # Nexus Repo NodePort Service
   annotations: {}
   nexus:
     enabled: false


### PR DESCRIPTION
This PR adds the following functionality (by default they are disabled):

- the ability to use a preexisting imagePullSecrets thru these values
```
  imagePullSecrets:
    # -- The base64 encoded dockerconfigjson
    secret: ""
    # -- Use an existing imagePullSecret created by a secrets operator
    existingSecret:
      # -- By default the existing secret is disabled, set this to true in order to provide an existing imagePullSecret
      enabled: false
      # -- The existing imagePullSecret name
      name: ""
```

- the ability to use a preexisting secret for database connection details thru these values:
```
    additionalEnv:
      null
      # -- Uncomment these when using secret.existingDbSecret.enabled = true
      # - name: DB_NAME
      #   valueFrom:
      #     secretKeyRef:
      #       name: secret-name
      #       key: secret-key
      # - name: DB_HOST
      #   valueFrom:
      #     secretKeyRef:
      #       name: secret-name
      #       key: secret-key
      # - name: DB_USER
      #   valueFrom:
      #     secretKeyRef:
      #       name: secret-name
      #       key: secret-key
      # - name: DB_PASSWORD
      #   valueFrom:
      #     secretKeyRef:
      #       name: secret-name
      #       key: secret-key
...
  secret:
    dbSecret:
      enabled: false # Enable to apply database-secret.yaml which allows you to specify db credentials
    # -- Use an existing secret for the database variables: DB_NAME, DB_HOST, DB_USER, DB_PASSWORD
    existingDbSecret:
      # -- Enabled the use of the already created secret
      enabled: true
```

- the ability to use a preexisting secret for the license file:
```
  license:
    name: nexus-repo-license.lic
    # -- Use an already created secret with the license contents in base64, it takes the name from the above field -> name: nexus-repo-license.lic and the mount path from below: licenseSecret.mountPath
    existingSecret: false
```

Also there are a couple of formatting fixes mostly done automatically by the IDE.

This has been tested in my environment and works as expected, also I have tested that it does not impact existing functionality.