### PR TITLE
feat: allow customization of eso API version

### DIFF
--- a/nxrm-ha/templates/eso-admin-secrets.yaml
+++ b/nxrm-ha/templates/eso-admin-secrets.yaml
@@ -1,6 +1,6 @@
 {{- if and (not .Values.aws.secretmanager.enabled) (not .Values.azure.keyvault.enabled) (not .Values.secret.nexusAdminSecret.enabled) }}
 {{- if .Values.externalsecrets.enabled  }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: {{ .Values.externalsecrets.apiVersion }}
 kind: ExternalSecret
 metadata:
   name: {{ template "nexus.name" . }}-external-adminsecret

--- a/nxrm-ha/templates/eso-database-secrets.yaml
+++ b/nxrm-ha/templates/eso-database-secrets.yaml
@@ -1,6 +1,6 @@
 {{- if and (not .Values.aws.secretmanager.enabled) (not .Values.azure.keyvault.enabled) (not .Values.secret.dbSecret.enabled) }}
 {{- if .Values.externalsecrets.enabled  }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: {{ .Values.externalsecrets.apiVersion }}
 kind: ExternalSecret
 metadata:
   name: {{ template "nexus.name" . }}-external-dbsecret

--- a/nxrm-ha/templates/eso-license-secrets.yaml
+++ b/nxrm-ha/templates/eso-license-secrets.yaml
@@ -1,6 +1,6 @@
 {{- if and (not .Values.aws.secretmanager.enabled) (not .Values.azure.keyvault.enabled) (not .Values.secret.license.licenseSecret.enabled) }}
 {{- if .Values.externalsecrets.enabled  }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: {{ .Values.externalsecrets.apiVersion }}
 kind: ExternalSecret
 metadata:
   name: {{ template "nexus.name" . }}-external-{{ .Values.secret.license.name }}

--- a/nxrm-ha/templates/eso-nexus-secrets.yaml
+++ b/nxrm-ha/templates/eso-nexus-secrets.yaml
@@ -1,6 +1,6 @@
 {{- if and (not .Values.secret.aws.nexusSecret.enabled ) (not .Values.secret.azure.nexusSecret.enabled) (not .Values.secret.nexusSecret.enabled) }}
 {{- if and .Values.externalsecrets.enabled .Values.externalsecrets.secrets.nexusSecret.enabled }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: {{ .Values.externalsecrets.apiVersion }}
 kind: ExternalSecret
 metadata:
   name: {{ template "nexus.name" . }}-external-{{ .Values.secret.nexusSecret.name }}

--- a/nxrm-ha/templates/eso-secret-store.yaml
+++ b/nxrm-ha/templates/eso-secret-store.yaml
@@ -1,6 +1,6 @@
 {{- if and (not .Values.aws.secretmanager.enabled) (not .Values.azure.keyvault.enabled) (not .Values.secret.dbSecret.enabled) }}
 {{- if .Values.externalsecrets.enabled  }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: {{ .Values.externalsecrets.apiVersion }}
 kind: SecretStore
 metadata:
   name: {{ template "nexus.name" . }}-{{ .Values.externalsecrets.secretstore.name }}

--- a/nxrm-ha/values.yaml
+++ b/nxrm-ha/values.yaml
@@ -252,6 +252,7 @@ service: # Nexus Repo NodePort Service
     publishNotReadyAddresses: true # We want all pods in the StatefulSet to have their addresses published even before they're ready.
 externalsecrets:
   enabled: false
+  apiVersion: external-secrets.io/v1beta1
   secretstore:
     name: nexus-secret-store
     spec:


### PR DESCRIPTION
[External-Secrets v0.17.0](https://github.com/external-secrets/external-secrets/releases/tag/v0.17.0) stops serving `v1beta1` so customers using ESO >= v0.17.0 will no longer be able to use ESO to sync secrets.

Let's enable customization of the ESO API version via values file tuning (suggested `Values.externalsecrets.apiVersion`) with a default of `v1beta1` to avoid breaking existing users.