### PR TITLE
NEXUS-50108: Clarify HPA support status in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,16 @@ HA requires the following:
 * A disk accessible to all active nodes for storing Nexus Repository logs and configuration settings used for generating the support zip
 
 If the Nexus Repository deployment will contain more than one Docker repository,  you must use one of the following:
-* An external load balancer (e.g., NGINX) as a [reverse proxy](https://help.sonatype.com/display/NXRM3M/Docker+Repository+Reverse+Proxy+Strategies) instead of the provided ingress for Docker YAML 
+* An external load balancer (e.g., NGINX) as a [reverse proxy](https://help.sonatype.com/display/NXRM3M/Docker+Repository+Reverse+Proxy+Strategies) instead of the provided ingress for Docker YAML
 * A [Docker Subdomain Connector](https://help.sonatype.com/repomanager3/nexus-repository-administration/formats/docker-registry/docker-subdomain-connector) with external DNS to route traffic to each Docker subdomain
+
+## Important: Horizontal Pod Autoscaler (HPA) Not Supported
+
+**Nexus Repository 3 HA is NOT designed for use with Kubernetes Horizontal Pod Autoscaler (HPA)** or similar auto-scaling technologies. Use a static pod count instead.
+
+**Reasons:**
+* Long-running background tasks (cleanup, replication, indexing) may be interrupted during scale-down
+* The application has a 5-second shutdown timeout which is insufficient for graceful task completion
+* Scale-down events can leave tasks in incomplete states
+
+For detailed information, see the [Helm chart README](nxrm-ha/README.md#horizontal-pod-autoscaler-hpa-support).

--- a/nxrm-ha/README.md
+++ b/nxrm-ha/README.md
@@ -35,6 +35,20 @@ This Helm chart is designed for Sonatype Nexus Repository Pro deployments with a
 ### Sticky Sessions for Load Balancers/Ingress
 > **_NOTE:_** Configuration of sticky sessions is not supported in this chart. If you require sticky sessions, you will need to configure this in your load balancer or ingress controller as applicable.
 
+### Horizontal Pod Autoscaler (HPA) Support
+
+> **_IMPORTANT:_** Nexus Repository 3 HA is **NOT** designed for use with Kubernetes Horizontal Pod Autoscaler (HPA) or similar auto-scaling technologies.
+
+#### Why HPA is Not Recommended:
+- **Long-running background tasks**: Nexus Repository executes long-running background tasks such as cleanup, replication, and indexing operations that may be interrupted during scale-down events.
+- **Insufficient shutdown timeout**: The application has a 5-second shutdown timeout for background job completion (QuartzThreadPool configuration), which is too short to allow graceful completion of long-running tasks.
+- **Incomplete task states**: Scale-down events can leave tasks in incomplete or inconsistent states, potentially affecting repository integrity.
+
+#### Recommended Configuration:
+- **Use a static replica count** based on your workload requirements (see `statefulset.replicaCount` in values.yaml)
+- **Do not configure HPA** or any auto-scaling mechanisms for Nexus HA pods
+- For sizing guidance, refer to the [Nexus Repository system requirements documentation](https://help.sonatype.com/repomanager3/product-information/system-requirements)
+
 ### Storage
 The default configuration uses an emptyDir volume for storing Nexus Repository logs. However, this is only for demonstration purposes. For production, we strongly recommend that
 you configure dynamic provisioning of persistent storage bound to a shared location, such as EFS/Azure File/NFS, which is accessible to all actives nodes in your Kubernetes cluster. 

--- a/nxrm-ha/values.yaml
+++ b/nxrm-ha/values.yaml
@@ -35,6 +35,9 @@ aws:
     clusterName: nxrm-nexus
 statefulset:
   serviceName: nxrm-statefulset-service
+  # IMPORTANT: Nexus Repository 3 HA is NOT designed for use with Horizontal Pod Autoscaler (HPA).
+  # Use a static replica count. Do not configure HPA or auto-scaling for Nexus HA pods.
+  # See README.md for detailed explanation of HPA limitations.
   replicaCount: 3
   clustered: true
   additionalVolumes:


### PR DESCRIPTION
## Summary
- Updated documentation across multiple files to clarify that Nexus Repository 3 HA does NOT support Horizontal Pod Autoscaler (HPA) or auto-scaling technologies.

## Changes Made
1. **nxrm-ha/values.yaml** - Added prominent IMPORTANT comment above replicaCount parameter warning users not to configure HPA
2. **nxrm-ha/README.md** - Added new "Horizontal Pod Autoscaler (HPA) Support" section with technical explanation
3. **README.md** - Added "Important: Horizontal Pod Autoscaler (HPA) Not Supported" section

## Technical Details
- Root cause: QuartzThreadPool 5-second timeout too short for long-running tasks
- No HPA-specific configuration in Helm chart (unlike IQ HA)
- No terminationGracePeriodSeconds or preStop hooks for graceful shutdown

## Test Plan
- [x] Documentation-only change, no code modifications
- [x] All files follow existing documentation style and formatting
- [x] Links verified and consistent across all documentation files

## JIRA
https://sonatype.atlassian.net/browse/NEXUS-50108

Generated with [Claude Code](https://claude.com/claude-code)