### PR TITLE
Update Jenkinsfiles to follow nexus-internal GitHub access patterns

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,10 @@
  */
 @Library(['private-pipeline-library', 'jenkins-shared']) _
 
+if (!currentBuild.fullProjectName.contains('main')) {
+  properties([disableConcurrentBuilds(abortPrevious: true)])
+}
+
 dockerizedBuildPipeline(
   retentionPolicy: RetentionPolicy.TEN_BUILDS,
   buildAndTest: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,12 +10,10 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
-@Library(['private-pipeline-library', 'jenkins-shared', 'nxrm-jenkins-shared']) _
+@Library(['private-pipeline-library', 'jenkins-shared']) _
 
 dockerizedBuildPipeline(
-  prepare: {
-    githubStatusUpdate('pending')
-  },
+  retentionPolicy: RetentionPolicy.TEN_BUILDS,
   buildAndTest: {
     sh './build.sh'
   },
@@ -23,9 +21,13 @@ dockerizedBuildPipeline(
   archiveArtifacts: 'docs/*',
   testResults: ['**/test-output.xml'],
   onSuccess: {
-    nxrmBuildNotifications(currentBuild, env)
+    if (env.BRANCH_NAME == 'main' && currentBuild?.previousBuild?.result =~ /FAILURE|UNSTABLE/) {
+      notifyChat(currentBuild: currentBuild, env: env, room: 'nxrm-notifications')
+    }
   },
   onFailure: {
-    nxrmBuildNotifications(currentBuild, env)
+    if (env.BRANCH_NAME == 'main') {
+      notifyChat(currentBuild: currentBuild, env: env, room: 'nxrm-notifications')
+    }
   }
 )

--- a/Jenkinsfile-Release
+++ b/Jenkinsfile-Release
@@ -12,8 +12,6 @@
  */
 @Library(['private-pipeline-library', 'jenkins-shared']) _
 
-def buildImageId = "nxrm3-ha-build:${env.BUILD_NUMBER}"
-
 properties([
   parameters([
     string(
@@ -33,6 +31,7 @@ pipeline {
     buildDiscarder(
       logRotator(numToKeepStr: '10')
     )
+    timeout(time: 15, unit: 'MINUTES')
     timestamps()
   }
   stages {
@@ -59,9 +58,12 @@ pipeline {
     }
     stage('Build and Test') {
       steps {
-        dockerPrepareBuildImage(buildImageId)
-        withDockerImage(buildImageId) {
-          sh './build.sh'
+        script {
+          def buildImageId = "nxrm3-ha-build:${env.BUILD_NUMBER}"
+          dockerPrepareBuildImage(buildImageId)
+          withDockerImage(buildImageId) {
+            sh './build.sh'
+          }
         }
       }
     }

--- a/Jenkinsfile-Release
+++ b/Jenkinsfile-Release
@@ -10,7 +10,9 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-@Library(['private-pipeline-library', 'jenkins-shared', 'nxrm-jenkins-shared']) _
+@Library(['private-pipeline-library', 'jenkins-shared']) _
+
+def buildImageId = "nxrm3-ha-build:${env.BUILD_NUMBER}"
 
 properties([
   parameters([
@@ -25,56 +27,71 @@ properties([
   ])
 ])
 
-final chartVersion = calculateChartVersion(params.chartVersion, params.appVersion)
-
-dockerizedBuildPipeline(
-  prepare: {
-    if (! params.appVersion) {
-      error('The appVersion is required.')
-    }
-    githubStatusUpdate('pending')
-  },
-  buildAndTest: {
-    sonatypeZionGitConfig()
-    runSafely "git checkout ${gitBranch(env)}"
-    runSafely "./upgrade.sh ./nxrm-ha ${chartVersion} ${params.appVersion}"
-    runSafely './build.sh'
-    runSafely 'git add nxrm-ha'
-  },
-  skipVulnerabilityScan: true,
-  archiveArtifacts: 'docs/*',
-  testResults: [],
-  deployCondition: { true },
-  deploy: {
-    runSafely 'git add docs'
-    runSafely "git commit -m 'Release Update for ${chartVersion}'"
-
-    sshagent(credentials: [sonatypeZionCredentialsId()]) {
-      runSafely 'git push'
-    }
-  },
-  postDeploy: {
-    // Create tags
-    String tagName = "${chartVersion}"
-    runSafely "git tag -a ${tagName} -m 'Release Update: ${chartVersion}'"
-    sshagent(credentials: [sonatypeZionCredentialsId()]) {
-      runSafely "git push origin ${tagName}"
-    }
-  },
-  onSuccess: {
-    nxrmBuildNotifications(currentBuild, env)
-  },
-  onFailure: {
-    nxrmBuildNotifications(currentBuild, env)
+pipeline {
+  agent { label 'ubuntu-zion' }
+  options {
+    buildDiscarder(
+      logRotator(numToKeepStr: '10')
+    )
+    timestamps()
   }
-)
+  stages {
+    stage('Prepare') {
+      steps {
+        script {
+          if (!params.appVersion) {
+            error('The appVersion is required.')
+          }
+        }
+        sonatypeZionGitConfig()
+        runSafely "git checkout ${gitBranch(env)}"
+      }
+    }
+    stage('Update Chart Version') {
+      steps {
+        script {
+          def chartVersion = calculateChartVersion(params.chartVersion, params.appVersion)
+          env.CHART_VERSION = chartVersion
+        }
+        runSafely "./upgrade.sh ./nxrm-ha ${env.CHART_VERSION} ${params.appVersion}"
+        runSafely 'git add nxrm-ha'
+      }
+    }
+    stage('Build and Test') {
+      steps {
+        dockerPrepareBuildImage(buildImageId)
+        withDockerImage(buildImageId) {
+          sh './build.sh'
+        }
+      }
+    }
+    stage('Commit, Tag and Push') {
+      steps {
+        runSafely 'git add docs'
+        runSafely "git commit -m 'Release Update for ${env.CHART_VERSION}'"
+        runSafely "git tag -a ${env.CHART_VERSION} -m 'Release Update: ${env.CHART_VERSION}'"
+        sshagent(credentials: [sonatypeZionCredentialsId()]) {
+          runSafely "git push origin ${gitBranch(env)} ${env.CHART_VERSION}"
+        }
+      }
+    }
+  }
+  post {
+    failure {
+      notifyChat(currentBuild: currentBuild, env: env, room: 'nxrm-notifications')
+    }
+    cleanup {
+      deleteDir()
+    }
+  }
+}
 
 String calculateChartVersion(final String chartVersion, final String appVersion) {
   if (chartVersion) {
     return chartVersion
   }
 
-  if (! appVersion) {
+  if (!appVersion) {
     error 'Failed to calculate chartVersion with no appVersion.'
   }
 
@@ -82,7 +99,7 @@ String calculateChartVersion(final String chartVersion, final String appVersion)
   final chartMajor = versionParts[1]
   final chartMinor = versionParts[2]
 
-  if (! chartMajor || ! chartMinor) {
+  if (!chartMajor || !chartMinor) {
     error "Failed to calculate chartVersion from appVersion: ${appVersion}"
   }
 


### PR DESCRIPTION
## Summary

Updates both Jenkinsfiles to follow the same GitHub access patterns used by nexus-internal.

## Changes

### Jenkinsfile (CI)
- Removed `nxrm-jenkins-shared` library dependency
- Removed explicit `githubStatusUpdate('pending')` (rely on Jenkins native integration)
- Replaced `nxrmBuildNotifications` with direct `notifyChat` on main branch
- Added `retentionPolicy: RetentionPolicy.TEN_BUILDS`
- Added `disableConcurrentBuilds(abortPrevious: true)` for feature branches

### Jenkinsfile-Release
- Removed `nxrm-jenkins-shared` library dependency
- Converted from `dockerizedBuildPipeline` to plain declarative pipeline (matches nexus-internal release pipeline structure)
- `sonatypeZionGitConfig()` runs on host agent instead of inside Docker container
- Git operations (checkout, add, commit, push, tag) all on host; only `build.sh` (helm) runs in Docker
- `sshagent(credentials: [sonatypeZionCredentialsId()])` wraps push operations
- Combined commit + tag into single `git push`
- Removed `githubStatusUpdate` calls
- Replaced `nxrmBuildNotifications` with `notifyChat` on failure
- Added 15-minute timeout
- Set retention to 10 builds
- Scoped `buildImageId` variable to its usage stage