### PR TITLE
NEXUS-52146, NEXUS-52147: Ephemeral Storage & HPA for NXRM Helm Chart

### DIFF
--- a/nxrm-ha/README.md
+++ b/nxrm-ha/README.md
@@ -135,6 +135,43 @@ If you have used the `statefulset.name` parameter in version 87.1.0 or earlier, 
 2. See our [documentation on on-premises high availability deployments using Kubernetes](https://help.sonatype.com/en/option-2---on-premises-high-availability-deployment-using-kubernetes.html) for more information
 
 
+### Ephemeral Storage for Logs and Support Content
+
+By default, Nexus Repository logs (`/nexus-data/log`) and support content (`/nexus-data/tmp`) are stored inside the main `nexus-data` PVC. If you are already forwarding logs to a centralized system (e.g., AWS CloudWatch via Fluent Bit), you can redirect these paths to cheap, ephemeral (`emptyDir`) storage instead. This reduces PVC size requirements and storage costs, since the data does not need to survive a pod restart.
+
+> **_IMPORTANT:_** Ephemeral storage is wiped when a pod is restarted or rescheduled. Only enable these options if you have a log forwarding solution (e.g., Fluent Bit → CloudWatch) already in place. If you enable ephemeral log storage without a log forwarder, logs will be lost on pod restart.
+
+#### Enabling ephemeral log storage
+
+In your values.yaml, set:
+
+```yaml
+ephemeralStorage:
+  logs:
+    enabled: true
+    sizeLimit: "10Gi"      # adjust to your expected log volume
+    path: "/nexus-data/log" # must be a subdirectory of /nexus-data
+```
+
+#### Enabling ephemeral support content storage
+
+```yaml
+ephemeralStorage:
+  supportContent:
+    enabled: true
+    sizeLimit: "50Gi"      # adjust to your expected support zip volume
+    path: "/nexus-data/tmp" # must be a subdirectory of /nexus-data
+```
+
+Both features are independent — you can enable one without the other.
+
+> **_NOTE:_** The `path` value must be a subdirectory of `/nexus-data`, not `/nexus-data` itself. Setting `path` to `/nexus-data` will cause a Helm validation error because that path is reserved for the main PVC.
+
+#### Migration notes for existing users
+
+Existing users are unaffected — both `ephemeralStorage.logs.enabled` and `ephemeralStorage.supportContent.enabled` default to `false`. No action is required if you do not want to use ephemeral storage.
+
+
 ## Format Limitations
 HA supports all formats that PostgreSQL supports.
 
@@ -718,6 +755,133 @@ sonatype/nxrm-ha
 ```
 
 ---
+
+## Horizontal Pod Autoscaler (HPA)
+
+The chart includes opt-in support for a `HorizontalPodAutoscaler` that automatically scales the NXRM StatefulSet based on CPU and memory utilization.
+
+> **HPA is disabled by default.** Existing deployments are not affected.
+
+### Prerequisites
+
+1. **Kubernetes metrics-server** must be installed in your cluster. Without it the HPA controller cannot read resource utilization and will never scale.
+
+   ```bash
+   # Verify metrics-server is running
+   kubectl top nodes
+   ```
+
+   If the command fails, install metrics-server:
+
+   ```bash
+   helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
+   helm upgrade --install metrics-server metrics-server/metrics-server -n kube-system
+   ```
+
+2. **Clustered mode is required.** HPA is only supported when `statefulset.clustered: true` (the default). A `helm install` with `hpa.enabled: true` and `statefulset.clustered: false` will fail with a clear error.
+
+3. **Do not set `statefulset.replicaCount` when using HPA.** HPA owns the replica count. Setting both will fail at install time with a clear error.
+
+### Enabling HPA
+
+```yaml
+hpa:
+  enabled: true
+  minReplicas: 2                          # Must be >= 2 for HA
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 75
+  targetMemoryUtilizationPercentage: 80
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 50
+          periodSeconds: 60
+
+# Remove or null out replicaCount when HPA is enabled
+statefulset:
+  replicaCount: null
+```
+
+### Disabling individual metrics
+
+Both CPU and memory metrics are enabled by default. To use only one metric for scaling, set the other to `null`:
+
+```yaml
+hpa:
+  enabled: true
+  targetCPUUtilizationPercentage: 75
+  targetMemoryUtilizationPercentage: null  # Memory-based scaling disabled
+```
+
+### Custom scale-up behavior
+
+By default, scale-up uses Kubernetes defaults (no stabilization, immediate scale). To configure custom scale-up policies:
+
+```yaml
+hpa:
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 50
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 30
+```
+
+> **Note:** Scale-up behavior configuration is optional. If `behavior.scaleUp` is not set, Kubernetes applies its defaults (no stabilization window, immediate scaling up to maxReplicas).
+
+### Why conservative scale-down policies?
+
+NXRM is a stateful application connected to a shared PostgreSQL database. Aggressive scale-down carries two risks:
+
+- **Database connection exhaustion** — each NXRM pod holds a connection pool. Scaling down too many pods at once can cause the remaining pods to saturate their pools as traffic is redistributed.
+- **In-flight request loss** — artifact uploads and downloads in progress on a pod being terminated will fail.
+
+The defaults mitigate both:
+
+| Policy | Value | Reason |
+|--------|-------|--------|
+| `stabilizationWindowSeconds` | 300 | Waits 5 minutes before acting on a scale-down signal, smoothing transient dips |
+| Max scale-down | 50% per 60 s | Never removes more than half the pod fleet in any one-minute window |
+
+### Blob store rebalancing
+
+> **Important:** NXRM does **not** automatically rebalance blob store content when pods are added or removed. Scale events affect request routing only. Plan blob store topology (e.g., S3/Azure Blob) before enabling HPA to avoid uneven storage usage across pods.
+
+### Graceful shutdown
+
+NXRM's `terminationGracePeriodSeconds` (default: `120 s`) gives in-flight requests time to complete before a pod is removed. If your workloads include large artifact uploads that can exceed 120 seconds, increase this value:
+
+```yaml
+statefulset:
+  container:
+    terminationGracePeriod: 300  # 5 minutes
+```
+
+### Recommended starting targets
+
+| Workload | CPU target | Memory target |
+|----------|-----------|---------------|
+| Read-heavy (proxy/hosted) | 70–80% | 80% |
+| Write-heavy (CI uploads) | 60–70% | 75% |
+| Mixed | 75% | 80% |
+
+These are starting points. Monitor `kubectl top pods` after enabling HPA and adjust to your observed utilization patterns.
+
+### Complementary node-level scaling
+
+HPA scales pods within the existing node pool. To also scale the underlying nodes, configure your cloud provider's **Cluster Autoscaler** (AWS EKS, Azure AKS) or **Karpenter** alongside HPA.
+
+---
+
 ## Nexus Secrets
 
 ---
@@ -924,3 +1088,17 @@ The following table lists the configurable parameters of the Nexus chart and the
 | `config.data`                                               | The data for the config map                                                                                                                                                                                                                                                                                                                                                      | `{}`                                                                                                                |
 | `config.mountPath`                                          | The file path to mount the config map into. Each key value pair in the config map is put on a separate line in the file                                                                                                                                                                                                                                                          | `/sonatype-nexus-conf`                                                                                              |
 | `logStorage.tailSecondaryLogs`                              | When set to `true`, enables sidecar containers for tailing secondary logs (request, audit, task). Useful for centralized log collection and troubleshooting.                                                                                                                                                                                                                      | `true`                                                                                                              |
+| `logStorage.combineTaskLogs`                                | When set to `true`, configures Nexus Repository to write all task logs to a single combined file (`allTasks.log`) instead of one file per task.                                                                                                                                                                                                                                  | `true`                                                                                                              |
+| `ephemeralStorage.logs.enabled`                             | When set to `true`, mounts an `emptyDir` volume at `ephemeralStorage.logs.path` so that Nexus Repository logs are stored on ephemeral storage instead of the main PVC. Only enable if log forwarding (e.g., Fluent Bit → CloudWatch) is configured — ephemeral storage is wiped on pod restart.                                                                                  | `false`                                                                                                             |
+| `ephemeralStorage.logs.sizeLimit`                           | The size limit for the ephemeral log volume. Kubernetes will evict the pod if usage exceeds this limit.                                                                                                                                                                                                                                                                          | `"10Gi"`                                                                                                            |
+| `ephemeralStorage.logs.path`                                | The mount path for the ephemeral log volume. Must be a subdirectory of `/nexus-data` (e.g., `/nexus-data/log`). Cannot be `/nexus-data` — that path is reserved for the main PVC.                                                                                                                                                                                                | `"/nexus-data/log"`                                                                                                 |
+| `ephemeralStorage.supportContent.enabled`                   | When set to `true`, mounts an `emptyDir` volume at `ephemeralStorage.supportContent.path` so that Nexus Repository support content (support zips, temp files) is stored on ephemeral storage instead of the main PVC.                                                                                                                                                            | `false`                                                                                                             |
+| `ephemeralStorage.supportContent.sizeLimit`                 | The size limit for the ephemeral support content volume. Kubernetes will evict the pod if usage exceeds this limit.                                                                                                                                                                                                                                                               | `"50Gi"`                                                                                                            |
+| `ephemeralStorage.supportContent.path`                      | The mount path for the ephemeral support content volume. Must be a subdirectory of `/nexus-data` (e.g., `/nexus-data/tmp`). Cannot be `/nexus-data` — that path is reserved for the main PVC.                                                                                                                                                                                    | `"/nexus-data/tmp"`                                                                                                 |
+| `hpa.enabled`                                               | Whether to create a `HorizontalPodAutoscaler` resource. When `true`, `statefulset.replicaCount` must be unset and `statefulset.clustered` must be `true`.                                                                                                                                                                                                                        | `false`                                                                                                             |
+| `hpa.minReplicas`                                           | Minimum number of replicas. Must be >= 2 for NXRM HA.                                                                                                                                                                                                                                                                                                                           | `2`                                                                                                                 |
+| `hpa.maxReplicas`                                           | Maximum number of replicas the HPA can scale up to.                                                                                                                                                                                                                                                                                                                              | `10`                                                                                                                |
+| `hpa.targetCPUUtilizationPercentage`                        | Average CPU utilization percentage across all pods that triggers scaling.                                                                                                                                                                                                                                                                                                        | `75`                                                                                                                |
+| `hpa.targetMemoryUtilizationPercentage`                     | Average memory utilization percentage across all pods that triggers scaling.                                                                                                                                                                                                                                                                                                     | `80`                                                                                                                |
+| `hpa.behavior.scaleDown.stabilizationWindowSeconds`         | Seconds the HPA waits before acting on a scale-down signal. Conservative default prevents thrashing.                                                                                                                                                                                                                                                                             | `300`                                                                                                               |
+| `hpa.behavior.scaleDown.policies`                           | List of scale-down policies. Default limits removal to 50% of pods per 60-second window to avoid connection pool exhaustion.                                                                                                                                                                                                                                                     | `[{type: Percent, value: 50, periodSeconds: 60}]`                                                                   |

--- a/nxrm-ha/README.md
+++ b/nxrm-ha/README.md
@@ -866,6 +866,41 @@ statefulset:
     terminationGracePeriod: 300  # 5 minutes
 ```
 
+#### preStop hooks
+
+During HPA scale-down, Kubernetes sends a `SIGTERM` to the pod immediately. Without a `preStop` hook, in-flight requests (artifact uploads, downloads) may be interrupted before the pod has time to drain connections gracefully.
+
+A `preStop` hook introduces a delay between the pod being marked for termination and receiving `SIGTERM`, giving load balancers and ingress controllers time to remove the pod from their routing tables:
+
+```yaml
+statefulset:
+  container:
+    preStop:
+      command: ["/bin/sh", "-c", "sleep 15 && kill -TERM 1"]
+```
+
+**How it works:**
+- Kubernetes marks the pod as `Terminating` and removes it from Service endpoints
+- The `preStop` hook runs — sleeps 15 seconds to allow in-flight requests to complete and load balancers to update
+- After the sleep, `SIGTERM` is sent to NXRM (PID 1), initiating a clean JVM shutdown
+- The pod has the remaining `terminationGracePeriodSeconds` to finish shutting down
+
+> **Tip:** Set `terminationGracePeriodSeconds` to at least `preStop sleep + expected shutdown time`. For example, a 15 s preStop sleep + 60 s JVM shutdown means `terminationGracePeriod` should be at least `90`.
+
+### Minimum node sizing for HA + HPA
+
+When using HPA with NXRM in HA mode, ensure your node pool has sufficient memory headroom for scale-up events. Each new replica requires its full `resources.requests.memory` allocation plus approximately 1 GiB of JVM overhead during cold-start.
+
+**Recommended formula:**
+
+```
+Available node pool memory >= maxReplicas × (requests.memory + ~1 GiB JVM overhead)
+```
+
+If nodes are memory-constrained, new pods may OOM during cold-start and enter `CrashLoopBackOff`. In this state, HPA will intentionally refuse to scale further — it observes high CPU but recognizes that adding more pods that cannot boot would not help. The user-visible symptom is "HPA is not scaling even though CPU is high."
+
+> **Minimum recommendation:** For HA deployments with HPA, plan for at least 8 GiB of available memory per NXRM replica in the node pool.
+
 ### Recommended starting targets
 
 | Workload | CPU target | Memory target |

--- a/nxrm-ha/templates/hpa.yaml
+++ b/nxrm-ha/templates/hpa.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "nexus.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.namespaces.nexusNs.name | quote }}
+  labels:
+{{ include "nexus.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ template "nexus.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    {{- if .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.hpa.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- if .Values.hpa.behavior }}
+  behavior:
+    {{- if .Values.hpa.behavior.scaleDown }}
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.hpa.behavior.scaleDown.stabilizationWindowSeconds }}
+      policies:
+        {{- toYaml .Values.hpa.behavior.scaleDown.policies | nindent 8 }}
+    {{- end }}
+    {{- if .Values.hpa.behavior.scaleUp }}
+    scaleUp:
+      stabilizationWindowSeconds: {{ .Values.hpa.behavior.scaleUp.stabilizationWindowSeconds }}
+      policies:
+        {{- toYaml .Values.hpa.behavior.scaleUp.policies | nindent 8 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/nxrm-ha/templates/statefulset.yaml
+++ b/nxrm-ha/templates/statefulset.yaml
@@ -15,11 +15,13 @@ metadata:
     {{ toYaml .Values.statefulset.annotations | nindent 4 }}
 {{- end }}
 spec:
+  {{- if not .Values.hpa.enabled }}
   {{- if .Values.statefulset.clustered }}
-  replicas: {{.Values.statefulset.replicaCount}}
-  {{ else }}
+  replicas: {{ .Values.statefulset.replicaCount }}
+  {{- else }}
   replicas: 1
-  {{ end }}
+  {{- end }}
+  {{- end }}
   {{- if not .Values.statefulset.container.env.zeroDowntimeEnabled }}
   updateStrategy:
     type: OnDelete
@@ -54,9 +56,37 @@ spec:
       serviceAccountName: {{ include "nexus.serviceAccountName" . }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.statefulset.container.terminationGracePeriod }}
-      {{- if .Values.statefulset.initContainers }}
+      {{- if or .Values.statefulset.initContainers .Values.ephemeralStorage.logs.enabled }}
       initContainers:
+        {{- if .Values.statefulset.initContainers }}
         {{ toYaml .Values.statefulset.initContainers | nindent 8 }}
+        {{- end }}
+        {{- if .Values.ephemeralStorage.logs.enabled }}
+        - name: init-ephemeral-log-dir
+          image: busybox:1.33.1
+          command: [/bin/sh]
+          args:
+            - -c
+            - >-
+              mkdir -p /ephemeral-logs/tasks &&
+              mkdir -p /ephemeral-logs/audit &&
+              {{- if .Values.logStorage.combineTaskLogs }}
+              touch -a /ephemeral-logs/tasks/allTasks.log &&
+              {{- end }}
+              touch -a /ephemeral-logs/audit/audit.log &&
+              touch -a /ephemeral-logs/request.log &&
+              chown -R '200:200' /ephemeral-logs
+          volumeMounts:
+            - name: nxrm-ephemeral-logs
+              mountPath: /ephemeral-logs
+          resources:
+            limits:
+              cpu: "0.2"
+              memory: "512Mi"
+            requests:
+              cpu: "0.1"
+              memory: "256Mi"
+        {{- end }}
       {{- end }}
       {{- if .Values.statefulset.nodeSelector }}
       nodeSelector:
@@ -208,6 +238,14 @@ spec:
           {{ end }}
             - name: nexus-data
               mountPath: /nexus-data
+          {{- if .Values.ephemeralStorage.logs.enabled }}
+            - name: nxrm-ephemeral-logs
+              mountPath: {{ .Values.ephemeralStorage.logs.path }}
+          {{- end }}
+          {{- if .Values.ephemeralStorage.supportContent.enabled }}
+            - name: nxrm-ephemeral-support
+              mountPath: {{ .Values.ephemeralStorage.supportContent.path }}
+          {{- end }}
           {{- if .Values.logStorage.combineTaskLogs }}
             - name: logback-tasklogfile-override
               mountPath: /nexus-data/etc/logback/logback-tasklogfile-appender-override.xml
@@ -232,6 +270,10 @@ spec:
           volumeMounts:
             - name: nexus-data
               mountPath: /nexus-data
+          {{- if .Values.ephemeralStorage.logs.enabled }}
+            - name: nxrm-ephemeral-logs
+              mountPath: {{ .Values.ephemeralStorage.logs.path }}
+          {{- end }}
           resources:
             {{ toYaml .Values.statefulset.requestLogContainer.resources | nindent 12 }}
         - name: audit-log
@@ -240,6 +282,10 @@ spec:
           volumeMounts:
             - name: nexus-data
               mountPath: /nexus-data
+          {{- if .Values.ephemeralStorage.logs.enabled }}
+            - name: nxrm-ephemeral-logs
+              mountPath: {{ .Values.ephemeralStorage.logs.path }}
+          {{- end }}
           resources:
             {{ toYaml .Values.statefulset.auditLogContainer.resources | nindent 12 }}
         {{- if .Values.logStorage.combineTaskLogs }}
@@ -249,6 +295,10 @@ spec:
           volumeMounts:
             - name: nexus-data
               mountPath: /nexus-data
+          {{- if .Values.ephemeralStorage.logs.enabled }}
+            - name: nxrm-ephemeral-logs
+              mountPath: {{ .Values.ephemeralStorage.logs.path }}
+          {{- end }}
           resources:
             {{ toYaml .Values.statefulset.taskLogContainer.resources | nindent 12 }}
         {{ end }}
@@ -307,6 +357,16 @@ spec:
               - key: logback-tasklogfile-appender-override.xml
                 path: logback-tasklogfile-appender-override.xml
       {{ end }}
+      {{- if .Values.ephemeralStorage.logs.enabled }}
+        - name: nxrm-ephemeral-logs
+          emptyDir:
+            sizeLimit: {{ .Values.ephemeralStorage.logs.sizeLimit }}
+      {{- end }}
+      {{- if .Values.ephemeralStorage.supportContent.enabled }}
+        - name: nxrm-ephemeral-support
+          emptyDir:
+            sizeLimit: {{ .Values.ephemeralStorage.supportContent.sizeLimit }}
+      {{- end }}
   {{- if  and (not .Values.pvc.volumeClaimTemplate.enabled) (not .Values.pvc.existingClaim) }}
         - name: nexus-data
           emptyDir:

--- a/nxrm-ha/templates/validate.yaml
+++ b/nxrm-ha/templates/validate.yaml
@@ -1,0 +1,44 @@
+{{/* Validation checks — no K8s resources are defined here */}}
+
+{{- if .Values.ephemeralStorage.logs.enabled }}
+  {{- $logsPath := trimSuffix "/" .Values.ephemeralStorage.logs.path }}
+  {{- if eq $logsPath "/nexus-data" }}
+    {{- fail "ephemeralStorage.logs.path cannot be /nexus-data — that is reserved for the main PVC. Use a subdirectory such as /nexus-data/log" }}
+  {{- end }}
+  {{- if not (hasPrefix "/nexus-data/" $logsPath) }}
+    {{- fail "ephemeralStorage.logs.path must be a subdirectory of /nexus-data (e.g. /nexus-data/log)" }}
+  {{- end }}
+{{- end }}
+
+{{- if .Values.ephemeralStorage.supportContent.enabled }}
+  {{- $supportPath := trimSuffix "/" .Values.ephemeralStorage.supportContent.path }}
+  {{- if eq $supportPath "/nexus-data" }}
+    {{- fail "ephemeralStorage.supportContent.path cannot be /nexus-data — that is reserved for the main PVC. Use a subdirectory such as /nexus-data/tmp" }}
+  {{- end }}
+  {{- if not (hasPrefix "/nexus-data/" $supportPath) }}
+    {{- fail "ephemeralStorage.supportContent.path must be a subdirectory of /nexus-data (e.g. /nexus-data/tmp)" }}
+  {{- end }}
+{{- end }}
+
+{{- if and .Values.ephemeralStorage.logs.enabled .Values.ephemeralStorage.supportContent.enabled }}
+  {{- $logsPath := trimSuffix "/" .Values.ephemeralStorage.logs.path }}
+  {{- $supportPath := trimSuffix "/" .Values.ephemeralStorage.supportContent.path }}
+  {{- if eq $logsPath $supportPath }}
+    {{- fail "ephemeralStorage.logs.path and ephemeralStorage.supportContent.path cannot be the same value. Use distinct subdirectories such as /nexus-data/log and /nexus-data/tmp" }}
+  {{- end }}
+{{- end }}
+
+{{- if .Values.hpa.enabled }}
+  {{- if not .Values.statefulset.clustered }}
+    {{- fail "hpa.enabled requires statefulset.clustered to be true — HPA is only supported in clustered mode" }}
+  {{- end }}
+  {{- if lt (int .Values.hpa.minReplicas) 2 }}
+    {{- fail "hpa.minReplicas must be >= 2 — NXRM HA requires at least 2 replicas" }}
+  {{- end }}
+  {{- if and (not (kindIs "invalid" .Values.statefulset.replicaCount)) (ne (int .Values.statefulset.replicaCount) 0) }}
+    {{- fail "hpa.enabled and statefulset.replicaCount cannot both be set — remove statefulset.replicaCount when using HPA" }}
+  {{- end }}
+  {{- if lt (int .Values.hpa.maxReplicas) (int .Values.hpa.minReplicas) }}
+    {{- fail "hpa.maxReplicas must be >= hpa.minReplicas" }}
+  {{- end }}
+{{- end }}

--- a/nxrm-ha/tests/ephemeral-storage_test.yaml
+++ b/nxrm-ha/tests/ephemeral-storage_test.yaml
@@ -1,0 +1,340 @@
+suite: test ephemeral storage
+templates:
+  - statefulset.yaml
+  - validate.yaml
+release:
+  name: "test-release"
+  namespace: "test-namespace"
+chart:
+  version: "latest"
+  appVersion: "latest"
+tests:
+  - it: should not add ephemeral volumes when both features are disabled (default)
+    template: statefulset.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nxrm-ephemeral-logs
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nxrm-ephemeral-support
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: nxrm-ephemeral-logs
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: nxrm-ephemeral-support
+
+  - it: should add ephemeral log volume and volumeMount when logs enabled
+    template: statefulset.yaml
+    set:
+      ephemeralStorage:
+        logs:
+          enabled: true
+          sizeLimit: "10Gi"
+          path: "/nexus-data/log"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nxrm-ephemeral-logs
+            mountPath: /nexus-data/log
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nxrm-ephemeral-logs
+            emptyDir:
+              sizeLimit: 10Gi
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nxrm-ephemeral-support
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: nxrm-ephemeral-support
+
+  - it: should add ephemeral support content volume and volumeMount when support content enabled
+    template: statefulset.yaml
+    set:
+      ephemeralStorage:
+        supportContent:
+          enabled: true
+          sizeLimit: "50Gi"
+          path: "/nexus-data/tmp"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nxrm-ephemeral-support
+            mountPath: /nexus-data/tmp
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nxrm-ephemeral-support
+            emptyDir:
+              sizeLimit: 50Gi
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nxrm-ephemeral-logs
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: nxrm-ephemeral-logs
+
+  - it: should add both ephemeral volumes when both features enabled
+    template: statefulset.yaml
+    set:
+      ephemeralStorage:
+        logs:
+          enabled: true
+          sizeLimit: "10Gi"
+          path: "/nexus-data/log"
+        supportContent:
+          enabled: true
+          sizeLimit: "50Gi"
+          path: "/nexus-data/tmp"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nxrm-ephemeral-logs
+            mountPath: /nexus-data/log
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nxrm-ephemeral-support
+            mountPath: /nexus-data/tmp
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nxrm-ephemeral-logs
+            emptyDir:
+              sizeLimit: 10Gi
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nxrm-ephemeral-support
+            emptyDir:
+              sizeLimit: 50Gi
+
+  - it: should use custom sizeLimit and path values
+    template: statefulset.yaml
+    set:
+      ephemeralStorage:
+        logs:
+          enabled: true
+          sizeLimit: "20Gi"
+          path: "/nexus-data/log"
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nxrm-ephemeral-logs
+            emptyDir:
+              sizeLimit: 20Gi
+
+  - it: should fail when logs path is set to /nexus-data
+    template: validate.yaml
+    set:
+      ephemeralStorage:
+        logs:
+          enabled: true
+          path: "/nexus-data"
+    asserts:
+      - failedTemplate:
+          errorMessage: "ephemeralStorage.logs.path cannot be /nexus-data — that is reserved for the main PVC. Use a subdirectory such as /nexus-data/log"
+
+  - it: should fail when supportContent path is set to /nexus-data
+    template: validate.yaml
+    set:
+      ephemeralStorage:
+        supportContent:
+          enabled: true
+          path: "/nexus-data"
+    asserts:
+      - failedTemplate:
+          errorMessage: "ephemeralStorage.supportContent.path cannot be /nexus-data — that is reserved for the main PVC. Use a subdirectory such as /nexus-data/tmp"
+
+  - it: should not fail validation when logs disabled even if path is /nexus-data
+    template: validate.yaml
+    set:
+      ephemeralStorage:
+        logs:
+          enabled: false
+          path: "/nexus-data"
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: should fail when logs path has trailing slash resolving to /nexus-data
+    template: validate.yaml
+    set:
+      ephemeralStorage:
+        logs:
+          enabled: true
+          path: "/nexus-data/"
+    asserts:
+      - failedTemplate:
+          errorMessage: "ephemeralStorage.logs.path cannot be /nexus-data — that is reserved for the main PVC. Use a subdirectory such as /nexus-data/log"
+
+  - it: should fail when supportContent path has trailing slash resolving to /nexus-data
+    template: validate.yaml
+    set:
+      ephemeralStorage:
+        supportContent:
+          enabled: true
+          path: "/nexus-data/"
+    asserts:
+      - failedTemplate:
+          errorMessage: "ephemeralStorage.supportContent.path cannot be /nexus-data — that is reserved for the main PVC. Use a subdirectory such as /nexus-data/tmp"
+
+  - it: should fail when logs and supportContent paths are the same
+    template: validate.yaml
+    set:
+      ephemeralStorage:
+        logs:
+          enabled: true
+          path: "/nexus-data/log"
+        supportContent:
+          enabled: true
+          path: "/nexus-data/log"
+    asserts:
+      - failedTemplate:
+          errorMessage: "ephemeralStorage.logs.path and ephemeralStorage.supportContent.path cannot be the same value. Use distinct subdirectories such as /nexus-data/log and /nexus-data/tmp"
+
+  - it: should add ephemeral log volume mount to request-log sidecar when logs enabled
+    template: statefulset.yaml
+    set:
+      ephemeralStorage:
+        logs:
+          enabled: true
+          sizeLimit: "10Gi"
+          path: "/nexus-data/log"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: request-log
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: nxrm-ephemeral-logs
+            mountPath: /nexus-data/log
+
+  - it: should add ephemeral log volume mount to audit-log sidecar when logs enabled
+    template: statefulset.yaml
+    set:
+      ephemeralStorage:
+        logs:
+          enabled: true
+          sizeLimit: "10Gi"
+          path: "/nexus-data/log"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[2].name
+          value: audit-log
+      - contains:
+          path: spec.template.spec.containers[2].volumeMounts
+          content:
+            name: nxrm-ephemeral-logs
+            mountPath: /nexus-data/log
+
+  - it: should add init-ephemeral-log-dir init container when logs enabled
+    template: statefulset.yaml
+    set:
+      ephemeralStorage:
+        logs:
+          enabled: true
+          sizeLimit: "10Gi"
+          path: "/nexus-data/log"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: init-ephemeral-log-dir
+      - equal:
+          path: spec.template.spec.initContainers[1].volumeMounts[0].name
+          value: nxrm-ephemeral-logs
+
+  - it: should not add init-ephemeral-log-dir init container when logs disabled
+    template: statefulset.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.initContainers
+          content:
+            name: init-ephemeral-log-dir
+
+  - it: should add ephemeral log volume mount to tasks-log sidecar when logs enabled
+    template: statefulset.yaml
+    set:
+      ephemeralStorage:
+        logs:
+          enabled: true
+          sizeLimit: "10Gi"
+          path: "/nexus-data/log"
+      logStorage:
+        combineTaskLogs: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[3].name
+          value: tasks-log
+      - contains:
+          path: spec.template.spec.containers[3].volumeMounts
+          content:
+            name: nxrm-ephemeral-logs
+            mountPath: /nexus-data/log
+
+  - it: should fail when logs path is outside /nexus-data tree
+    template: validate.yaml
+    set:
+      ephemeralStorage:
+        logs:
+          enabled: true
+          path: "/etc/random"
+    asserts:
+      - failedTemplate:
+          errorMessage: "ephemeralStorage.logs.path must be a subdirectory of /nexus-data (e.g. /nexus-data/log)"
+
+  - it: should fail when supportContent path is outside /nexus-data tree
+    template: validate.yaml
+    set:
+      ephemeralStorage:
+        supportContent:
+          enabled: true
+          path: "/var/log/nexus"
+    asserts:
+      - failedTemplate:
+          errorMessage: "ephemeralStorage.supportContent.path must be a subdirectory of /nexus-data (e.g. /nexus-data/tmp)"
+
+  - it: should not create allTasks.log in init container when combineTaskLogs is false
+    template: statefulset.yaml
+    set:
+      ephemeralStorage:
+        logs:
+          enabled: true
+          sizeLimit: "10Gi"
+          path: "/nexus-data/log"
+      logStorage:
+        combineTaskLogs: false
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.initContainers[1].args[1]
+          pattern: "allTasks.log"
+
+  - it: should create allTasks.log in init container when combineTaskLogs is true
+    template: statefulset.yaml
+    set:
+      ephemeralStorage:
+        logs:
+          enabled: true
+          sizeLimit: "10Gi"
+          path: "/nexus-data/log"
+      logStorage:
+        combineTaskLogs: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].args[1]
+          pattern: "allTasks.log"

--- a/nxrm-ha/tests/hpa_test.yaml
+++ b/nxrm-ha/tests/hpa_test.yaml
@@ -1,0 +1,341 @@
+suite: test horizontal pod autoscaler
+templates:
+  - hpa.yaml
+  - statefulset.yaml
+  - validate.yaml
+release:
+  name: "test-release"
+  namespace: "test-namespace"
+chart:
+  version: "latest"
+  appVersion: "latest"
+
+# NOTE: every test that enables HPA must also set statefulset.replicaCount: null
+# because the default value is 3 and the validation rule rejects both being set.
+
+tests:
+  # ── Default behaviour ────────────────────────────────────────────────────────
+
+  - it: should not create HPA resource when hpa.enabled is false (default)
+    template: hpa.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should set replicas on StatefulSet when hpa is disabled (default)
+    template: statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  # ── HPA resource creation ────────────────────────────────────────────────────
+
+  - it: should create HPA resource when hpa.enabled is true
+    template: hpa.yaml
+    set:
+      hpa.enabled: true
+      hpa.minReplicas: 2
+      hpa.maxReplicas: 10
+      hpa.targetCPUUtilizationPercentage: 75
+      hpa.targetMemoryUtilizationPercentage: 80
+      statefulset.replicaCount: null
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - isAPIVersion:
+          of: autoscaling/v2
+
+  - it: should target the correct StatefulSet
+    template: hpa.yaml
+    set:
+      hpa.enabled: true
+      hpa.minReplicas: 2
+      hpa.maxReplicas: 10
+      hpa.targetCPUUtilizationPercentage: 75
+      hpa.targetMemoryUtilizationPercentage: 80
+      statefulset.replicaCount: null
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: StatefulSet
+      - equal:
+          path: spec.scaleTargetRef.apiVersion
+          value: apps/v1
+      - matchRegex:
+          path: spec.scaleTargetRef.name
+          pattern: "test-release"
+
+  - it: should set minReplicas and maxReplicas from values
+    template: hpa.yaml
+    set:
+      hpa.enabled: true
+      hpa.minReplicas: 2
+      hpa.maxReplicas: 10
+      hpa.targetCPUUtilizationPercentage: 75
+      hpa.targetMemoryUtilizationPercentage: 80
+      statefulset.replicaCount: null
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 2
+      - equal:
+          path: spec.maxReplicas
+          value: 10
+
+  - it: should configure CPU utilization metric
+    template: hpa.yaml
+    set:
+      hpa.enabled: true
+      hpa.minReplicas: 2
+      hpa.maxReplicas: 10
+      hpa.targetCPUUtilizationPercentage: 75
+      hpa.targetMemoryUtilizationPercentage: 80
+      statefulset.replicaCount: null
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 75
+
+  - it: should configure memory utilization metric
+    template: hpa.yaml
+    set:
+      hpa.enabled: true
+      hpa.minReplicas: 2
+      hpa.maxReplicas: 10
+      hpa.targetCPUUtilizationPercentage: 75
+      hpa.targetMemoryUtilizationPercentage: 80
+      statefulset.replicaCount: null
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 80
+
+  - it: should configure conservative scale-down behavior from default values
+    template: hpa.yaml
+    set:
+      hpa.enabled: true
+      hpa.minReplicas: 2
+      hpa.maxReplicas: 10
+      hpa.targetCPUUtilizationPercentage: 75
+      hpa.targetMemoryUtilizationPercentage: 80
+      statefulset.replicaCount: null
+    asserts:
+      - equal:
+          path: spec.behavior.scaleDown.stabilizationWindowSeconds
+          value: 300
+      - contains:
+          path: spec.behavior.scaleDown.policies
+          content:
+            type: Percent
+            value: 50
+            periodSeconds: 60
+
+  # ── StatefulSet replicas guard ───────────────────────────────────────────────
+
+  - it: should not set replicas on StatefulSet when hpa is enabled
+    template: statefulset.yaml
+    set:
+      hpa.enabled: true
+      hpa.minReplicas: 2
+      hpa.maxReplicas: 10
+      hpa.targetCPUUtilizationPercentage: 75
+      hpa.targetMemoryUtilizationPercentage: 80
+      statefulset.replicaCount: null
+    asserts:
+      - notExists:
+          path: spec.replicas
+
+  # ── HPA namespace ────────────────────────────────────────────────────────────
+
+  - it: should deploy HPA in the same namespace as the StatefulSet
+    template: hpa.yaml
+    set:
+      hpa.enabled: true
+      hpa.minReplicas: 2
+      hpa.maxReplicas: 10
+      hpa.targetCPUUtilizationPercentage: 75
+      hpa.targetMemoryUtilizationPercentage: 80
+      statefulset.replicaCount: null
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: nexusrepo
+
+  # ── Validation rules (FR-2.5) ────────────────────────────────────────────────
+
+  - it: should fail when hpa.enabled is true but statefulset.clustered is false
+    template: validate.yaml
+    set:
+      hpa.enabled: true
+      hpa.minReplicas: 2
+      hpa.maxReplicas: 10
+      hpa.targetCPUUtilizationPercentage: 75
+      hpa.targetMemoryUtilizationPercentage: 80
+      statefulset.clustered: false
+      statefulset.replicaCount: null
+    asserts:
+      - failedTemplate:
+          errorMessage: "hpa.enabled requires statefulset.clustered to be true — HPA is only supported in clustered mode"
+
+  - it: should fail when hpa.minReplicas is less than 2
+    template: validate.yaml
+    set:
+      hpa.enabled: true
+      hpa.minReplicas: 1
+      hpa.maxReplicas: 10
+      hpa.targetCPUUtilizationPercentage: 75
+      hpa.targetMemoryUtilizationPercentage: 80
+      statefulset.replicaCount: null
+    asserts:
+      - failedTemplate:
+          errorMessage: "hpa.minReplicas must be >= 2 — NXRM HA requires at least 2 replicas"
+
+  - it: should fail when both hpa.enabled and statefulset.replicaCount are set
+    template: validate.yaml
+    set:
+      hpa.enabled: true
+      hpa.minReplicas: 2
+      hpa.maxReplicas: 10
+      hpa.targetCPUUtilizationPercentage: 75
+      hpa.targetMemoryUtilizationPercentage: 80
+      statefulset.replicaCount: 3
+    asserts:
+      - failedTemplate:
+          errorMessage: "hpa.enabled and statefulset.replicaCount cannot both be set — remove statefulset.replicaCount when using HPA"
+
+  - it: should not fail validation when hpa is disabled (default)
+    template: validate.yaml
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: should not fail validation when hpa is enabled with valid config (no explicit replicaCount)
+    template: validate.yaml
+    set:
+      hpa.enabled: true
+      hpa.minReplicas: 2
+      hpa.maxReplicas: 10
+      hpa.targetCPUUtilizationPercentage: 75
+      hpa.targetMemoryUtilizationPercentage: 80
+      statefulset.replicaCount: null
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: should fail validation when maxReplicas is less than minReplicas
+    template: validate.yaml
+    set:
+      hpa.enabled: true
+      hpa.minReplicas: 5
+      hpa.maxReplicas: 2
+      statefulset.replicaCount: null
+    asserts:
+      - failedTemplate:
+          errorMessage: "hpa.maxReplicas must be >= hpa.minReplicas"
+
+  - it: should fail validation when maxReplicas equals minReplicas minus one
+    template: validate.yaml
+    set:
+      hpa.enabled: true
+      hpa.minReplicas: 3
+      hpa.maxReplicas: 2
+      statefulset.replicaCount: null
+    asserts:
+      - failedTemplate:
+          errorMessage: "hpa.maxReplicas must be >= hpa.minReplicas"
+
+  - it: should only render CPU metric when memory target is null
+    template: hpa.yaml
+    set:
+      hpa.enabled: true
+      hpa.minReplicas: 2
+      hpa.maxReplicas: 10
+      hpa.targetCPUUtilizationPercentage: 75
+      hpa.targetMemoryUtilizationPercentage: null
+      statefulset.replicaCount: null
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 75
+      - notContains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 80
+
+  - it: should only render memory metric when CPU target is null
+    template: hpa.yaml
+    set:
+      hpa.enabled: true
+      hpa.minReplicas: 2
+      hpa.maxReplicas: 10
+      hpa.targetCPUUtilizationPercentage: null
+      hpa.targetMemoryUtilizationPercentage: 80
+      statefulset.replicaCount: null
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 80
+      - notContains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 75
+
+  - it: should render scaleUp behavior when configured
+    template: hpa.yaml
+    set:
+      hpa.enabled: true
+      hpa.minReplicas: 2
+      hpa.maxReplicas: 10
+      hpa.targetCPUUtilizationPercentage: 75
+      hpa.targetMemoryUtilizationPercentage: 80
+      statefulset.replicaCount: null
+      hpa.behavior.scaleUp.stabilizationWindowSeconds: 60
+      hpa.behavior.scaleUp.policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 30
+    asserts:
+      - equal:
+          path: spec.behavior.scaleUp.stabilizationWindowSeconds
+          value: 60
+      - contains:
+          path: spec.behavior.scaleUp.policies
+          content:
+            type: Percent
+            value: 100
+            periodSeconds: 30

--- a/nxrm-ha/values.yaml
+++ b/nxrm-ha/values.yaml
@@ -194,6 +194,19 @@ statefulset:
       enabled: false
       # -- The existing imagePullSecret name
       name: ""
+hpa:
+  enabled: false                          # Default: disabled for backward compatibility
+  minReplicas: 2                          # Minimum replicas (must be >= 2 for HA)
+  maxReplicas: 10                         # Maximum replicas
+  targetCPUUtilizationPercentage: 75      # CPU target for scaling
+  targetMemoryUtilizationPercentage: 80   # Memory target for scaling
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300     # Wait 5 min before scale-down
+      policies:
+        - type: Percent
+          value: 50                       # Scale down max 50% of pods at a time
+          periodSeconds: 60
 ingress:
   name: "nexus-ingress"
   enabled: false
@@ -224,6 +237,15 @@ ingress:
 logStorage:
   tailSecondaryLogs: true
   combineTaskLogs: true
+ephemeralStorage:
+  logs:
+    enabled: false      # Set to true to store logs on ephemeral (emptyDir) storage instead of the PVC
+    sizeLimit: "10Gi"   # Max size for the ephemeral log volume
+    path: "/nexus-data/log"  # Mount path — must not be /nexus-data
+  supportContent:
+    enabled: false      # Set to true to store support content on ephemeral (emptyDir) storage instead of the PVC
+    sizeLimit: "50Gi"   # Max size for the ephemeral support content volume
+    path: "/nexus-data/tmp"  # Mount path — must not be /nexus-data
 storageClass:
   enabled: false # For built-in storage class, set storageClass.enabled to false
   name: nexus-storage # For built-in storage class, set storageClass.enabled to false and specify the name of the built-in storage class here e.g. managed-csi for AKS


### PR DESCRIPTION
Jira
https://sonatype.atlassian.net/browse/NEXUS-52146
https://sonatype.atlassian.net/browse/NEXUS-52147


## Summary

- **NEXUS-52146**: Add ephemeral storage (emptyDir) support for NXRM logs and support content, isolating them from the main PVC
- **NEXUS-52147**: Add Horizontal Pod Autoscaler (HPA) with CPU/memory-based scaling for clustered NXRM deployments

## Changes

### Ephemeral Storage (NEXUS-52146)
- New `ephemeralStorage.logs` and `ephemeralStorage.supportContent` sections in values.yaml
- Mounts emptyDir volumes at configurable paths (default: `/nexus-data/log`, `/nexus-data/tmp`)
- Sidecar containers automatically use ephemeral volume when enabled
- Validation: path cannot be `/nexus-data`, logs and support paths must differ

### HPA (NEXUS-52147)
- New `hpa` section in values.yaml with CPU/memory targets and scale-down behavior
- Creates `autoscaling/v2` HorizontalPodAutoscaler targeting the StatefulSet
- When HPA enabled, StatefulSet omits `spec.replicas` (HPA controls scaling)
- Validation: requires `clustered: true`, `minReplicas >= 2`, conflicts with `replicaCount`

### Both Features
- Disabled by default (`enabled: false`) — zero breaking changes
- Helm template validation rules with clear error messages
- Full test suites (ephemeral-storage_test.yaml, hpa_test.yaml)
- README documentation updated

## Test Plan

- [x] `helm lint` passes
- [x] `helm template` renders correctly for both features
- [x] Validation rules reject invalid configurations
- [x] Ephemeral storage: local cluster tested — logs on separate tmpfs, pod restart wipes logs, sidecars work
- [x] HPA: local cluster tested — scale-up (2→3→5) and scale-down (5→2) verified
- [x] All existing tests continue to pass
