### PR TITLE
NEXUS-52148: Add Azure Workload Identity support via External Secrets…

### DIFF
--- a/nxrm-ha/README.md
+++ b/nxrm-ha/README.md
@@ -286,101 +286,176 @@ Azure Key Vault is disabled by default. If you would like to store your database
     * Ensure `secret.aws.nexusSecret.enabled ` and `aws.secretmanager.enabled` are false
 
 
-##### External Secrets Operator
-- Ensure you have installed the [external secrets operator](https://external-secrets.io/latest/)
-- Ensure you have granted the necessary permissions for accessing your external secret store:
-- You'll need to create a service account and create a trust relationship between Azure AD and that Kubernetes service account:
-    - See [Workload identity](https://external-secrets.io/latest/provider/azure-key-vault/#workload-identity)
-    - See 'Referenced Service Account' section of [Workload identity](https://external-secrets.io/latest/provider/azure-key-vault/#workload-identity)
+##### External Secrets Operator with Azure Workload Identity
 
-##### Guidance for setting up permissions needed for External Secrets Operator on Azure (AKS)
-- According to https://external-secrets.io/latest/provider/azure-key-vault/#authentication the recommended way to authenticate external secrets operator for Azure Key Vault is through workload identity.
-- We tried this out by following the steps on the page at: https://azure.github.io/azure-workload-identity/docs/quick-start.html which is referenced from https://external-secrets.io/latest/provider/azure-key-vault/#authentication :
-    - According to https://azure.github.io/azure-workload-identity/docs/quick-start.html you can either use the azwi (Azure Workload Identity) tool for Azure Active Directory (AAD) application or use az cli for  user-assigned managed identity, we opted for azwi tool. See next section for details.
+This section covers using the [External Secrets Operator (ESO)](https://external-secrets.io/latest/) with Azure Workload Identity to securely pull secrets from Azure Key Vault into your NXRM deployment — without storing credentials in Kubernetes.
 
-##### Setting up permissions using The Azure Workload Identity tool for Azure Active Directory (AAD) application
-- Install azwi :  See https://azure.github.io/azure-workload-identity/docs/installation/azwi.html for brew command
-- Open a shell
-    - [Set the following env variables](https://azure.github.io/azure-workload-identity/docs/quick-start.html#2-export-environment-variables):
-      ```
-      export APPLICATION_NAME=nexus-repo-aks-aad
-      export KEYVAULT_NAME=test-nexusha-secrets (your key vault name)
-      export KEYVAULT_SCOPE=$(az keyvault show --name "${KEYVAULT_NAME}" --query id -o tsv)
-      export SERVICE_ACCOUNT_NAMESPACE=nexusrepo (must be same as namespace in values.yaml of ha helm chart)
-      export SERVICE_ACCOUNT_NAME=nexus-repository-dev-ha-sa. (Must be same as that specified in values.yaml of ha helm chart)
-      export SERVICE_ACCOUNT_ISSUER=$(az aks show --resource-group nexus-repo-ha --name nexus-repo-ha-aks --query "oidcIssuerProfile.issuerUrl" -otsv)
-      ```
+> **Backward compatibility:** The existing Secret Store CSI Driver path (`azure.keyvault.enabled: true`) remains fully supported. Both approaches can coexist in the same cluster on different namespaces. Choose the one that best fits your operational model.
 
-    - [Create Key Vault](https://azure.github.io/azure-workload-identity/docs/quick-start.html#3-create-an-azure-key-vault-and-secret)
+###### Choosing between Secret Store CSI Driver and External Secrets Operator
 
-        - [Create an AAD application or user-assigned managed identity and grant permissions to access the secret](https://azure.github.io/azure-workload-identity/docs/quick-start.html#4-create-an-aad-application-or-user-assigned-managed-identity-and-grant-permissions-to-access-the-secret)
-            - `azwi serviceaccount create phase app --aad-application-name "${APPLICATION_NAME}"`
-            - Output should be like:
-                ```
-                INFO[0000] No subscription provided, using selected subscription from Azure CLI: REDACTED
-                INFO[0005] [aad-application] created an AAD application  clientID=REDACTED name=azwi-test objectID=REDACTED
-                WARN[0005] --service-principal-name not specified, falling back to AAD application name
-                INFO[0005] [aad-application] created service principal   clientID=REDACTED name=azwi-test objectID=REDACTED
-                ```
-            - Make a note of the client id value in the output as you’ll need it for your helm values.yaml. You’ll also need to know your Azure tenant id for your helm values.yaml. You can find out from the Azure portal or use this command to find out from the AAD application you just created:
-              `az ad sp list --display-name "${APPLICATION_NAME}" --query '[0].appOwnerOrganizationId' -otsv`
+| | Secret Store CSI Driver | External Secrets Operator (ESO) |
+|---|---|---|
+| **How secrets arrive** | Mounted as files in the pod via CSI volume | Synced into native Kubernetes Secrets |
+| **Secret rotation** | Automatic via CSI driver poll interval | Automatic via ESO `refreshInterval` |
+| **Multi-cloud support** | AWS + Azure only | AWS, Azure, GCP, HashiCorp Vault, and more |
+| **Authentication** | Pod identity / managed identity | Workload Identity (recommended) |
+| **Kubernetes-native** | Requires CSI driver DaemonSet | CRD-based, no DaemonSet needed |
+| **Best for** | Simple single-cloud deployments | Multi-cloud, GitOps, or centralized secret management |
 
-            - Set access policy for the AAD application or user-assigned managed identity to access the keyvault secret:
-                - If your key vault is using RBAC use the command below
-                  ```
-                  export APPLICATION_CLIENT_ID="$(az ad sp list --display-name "${APPLICATION_NAME}" --query '[0].appId' -otsv)"
-                  az role assignment create --role "Key Vault Secrets User" --assignee $APPLICATION_CLIENT_ID --scope $KEYVAULT_SCOPE
-                  ```
-                  (RBAC Key Vault command source: https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access#configure-managed-identity )
+###### Prerequisites
 
-                - If your Key vault is not using RBAC (i.e. if you’re using user-assigned managed identity) then you can use command below:
-                  ```
-                  export APPLICATION_CLIENT_ID="$(az ad sp list --display-name "${APPLICATION_NAME}" --query '[0].appId' -otsv)"
-                  az keyvault set-policy --name "${KEYVAULT_NAME}" --secret-permissions get --spn "${APPLICATION_CLIENT_ID}"
-                  ```
-                  (source: https://azure.github.io/azure-workload-identity/docs/quick-start.html#4-create-an-aad-application-or-user-assigned-managed-identity-and-grant-permissions-to-access-the-secret )
-            - Skip [Create a Kubernetes service account](https://azure.github.io/azure-workload-identity/docs/quick-start.html#5-create-a-kubernetes-service-account)
-                - We will skip this since our nxrm-ha helm chart will be doing this for us. We’ll just need to make sure we specify the appropriate annotations and labels to the service account the helm chart will create (see below)
+Before enabling External Secrets with Workload Identity, ensure:
 
-            - [Establish federated identity credential between the identity and the service account issuer & subject](https://azure.github.io/azure-workload-identity/docs/quick-start.html#6-establish-federated-identity-credential-between-the-identity-and-the-service-account-issuer--subject)
-              ``` 
-                azwi serviceaccount create phase federated-identity \ 
-                --aad-application-name "${APPLICATION_NAME}" \ 
-                --service-account-namespace "${SERVICE_ACCOUNT_NAMESPACE}" \ 
-                --service-account-name "${SERVICE_ACCOUNT_NAME}" \ 
-                --service-account-issuer-url "${SERVICE_ACCOUNT_ISSUER}"
-              ```
-                - Output should be like:
-                  ```
-                    INFO[0000] No subscription provided, using selected subscription from Azure CLI: REDACTED
-                    INFO[0032] [federated-identity] added federated credential  objectID=REDACTED subject="system:serviceaccount:default:workload-identity-sa"
-                  ```
-            - Update your nxrm-ha values.yaml:
-                - Service account section:
-                  ```
-                  serviceAccount:
-                     enabled: true
-                     name: nexus-repository-dev-ha-sa #
-                     labels:
-                        azure.workload.identity/use: "true"
-                     annotations:
-                        azure.workload.identity/client-id: ab67cbbb-e374-4586-bcb6-8d80df659b41
-                        azure.workload.identity/tenant-id: bd28fc0b-f086-430f-ac20-16268536c81f
-                  ```
-                - External secrets:
-                  ```
-                  externalsecrets:
-                     enabled: true
-                     secretstore:
-                        name: nexus-secret-store
-                        spec:
-                           provider:
-                              azurekv:
-                                 authType: WorkloadIdentity
-                                 vaultUrl: "https://test-nexusha-secrets.vault.azure.net/" #use your key vault url here
-                                 serviceAccountRef:
-                                    name: nexus-repository-dev-ha-sa # use same service account name as specified in serviceAccount.name
-                  ```
+1. **AKS cluster** created with OIDC issuer and Workload Identity enabled:
+   ```bash
+   # For new clusters:
+   az aks create -g <rg> -n <aks-name> --enable-oidc-issuer --enable-workload-identity
+
+   # For existing clusters:
+   az aks update -g <rg> -n <aks-name> --enable-oidc-issuer --enable-workload-identity
+   ```
+
+2. **External Secrets Operator** installed on the cluster:
+   ```bash
+   helm repo add external-secrets https://charts.external-secrets.io
+   helm install external-secrets external-secrets/external-secrets \
+     -n external-secrets --create-namespace
+   ```
+
+3. **Azure Key Vault** provisioned with the secrets NXRM needs (see step 5 below).
+
+> **Important:** If any of these prerequisites are missing, the SecretStore will remain in `Ready=False` with no helpful error message. Verify all prerequisites before enabling ESO in the chart.
+
+###### Step-by-step Azure setup
+
+**1. Create a User Assigned Managed Identity:**
+```bash
+az identity create -g <rg> -n nxrm-wi
+```
+
+**2. Get the AKS OIDC issuer URL:**
+```bash
+OIDC_URL=$(az aks show -g <aks-rg> -n <aks-name> \
+  --query oidcIssuerProfile.issuerUrl -o tsv)
+```
+
+**3. Create a federated credential mapping the Kubernetes ServiceAccount to the managed identity:**
+```bash
+az identity federated-credential create \
+  -g <rg> \
+  --identity-name nxrm-wi \
+  -n fed-nxrm \
+  --issuer "$OIDC_URL" \
+  --subject system:serviceaccount:<namespace>:<sa-name> \
+  --audience api://AzureADTokenExchange
+```
+Replace `<namespace>` with your NXRM namespace (e.g., `nexusrepo`) and `<sa-name>` with the ServiceAccount name you’ll use in values.yaml.
+
+**4. Grant the managed identity `Key Vault Secrets User` on your Key Vault:**
+```bash
+az role assignment create \
+  --role "Key Vault Secrets User" \
+  --assignee-object-id <umi-principal-id> \
+  --assignee-principal-type ServicePrincipal \
+  --scope <kv-resource-id>
+```
+You can find the principal ID with:
+```bash
+az identity show -g <rg> -n nxrm-wi --query principalId -o tsv
+```
+
+**5. Populate Azure Key Vault with the required secrets:**
+
+The chart’s ExternalSecrets reference these secrets by default:
+
+| Chart secret | Default Key Vault secret name | Contains |
+|---|---|---|
+| Database credentials | `nxrm-db-user`, `nxrm-db-password`, `nxrm-db-host` | PostgreSQL user, password, host |
+| Admin password | `nxrm-admin-password` | Initial NXRM admin password |
+| License | `nxrm-license` | Nexus Repository Pro license (base64-encoded) |
+
+> **Note:** Azure Key Vault secret names must be 1-127 characters containing only alphanumerics and dashes. The chart defaults (`username`, `password`, `host`) are overridable via `externalsecrets.secrets.*.providerSecretName` — use the names above or your own convention.
+
+**6. Configure the Helm chart values:**
+```yaml
+serviceAccount:
+  enabled: true
+  name: <sa-name>
+  labels:
+    azure.workload.identity/use: "true"
+  annotations:
+    azure.workload.identity/client-id: <umi-client-id>
+    azure.workload.identity/tenant-id: <tenant-id>
+
+externalsecrets:
+  enabled: true
+  secretstore:
+    spec:
+      provider:
+        azurekv:
+          authType: WorkloadIdentity
+          vaultUrl: https://<kv-name>.vault.azure.net/
+          serviceAccountRef:
+            name: <sa-name>
+```
+
+You can find the client ID and tenant ID with:
+```bash
+az identity show -g <rg> -n nxrm-wi --query ‘{clientId: clientId, tenantId: tenantId}’ -o table
+```
+
+###### Migrating from Secret Store CSI Driver to External Secrets Operator
+
+If you are currently using the CSI Driver path (`azure.keyvault.enabled: true`) and want to migrate to ESO:
+
+1. **Complete the Azure setup above** (steps 1–5) — the managed identity, federated credential, and Key Vault RBAC must be in place before switching.
+
+2. **Update your values.yaml:**
+   ```yaml
+   # Disable the old CSI driver path
+   azure:
+     keyvault:
+       enabled: false
+
+   # Enable the new ESO path
+   serviceAccount:
+     enabled: true
+     name: <sa-name>
+     labels:
+       azure.workload.identity/use: "true"
+     annotations:
+       azure.workload.identity/client-id: <umi-client-id>
+       azure.workload.identity/tenant-id: <tenant-id>
+
+   externalsecrets:
+     enabled: true
+     secretstore:
+       spec:
+         provider:
+           azurekv:
+             authType: WorkloadIdentity
+             vaultUrl: https://<kv-name>.vault.azure.net/
+             serviceAccountRef:
+               name: <sa-name>
+   ```
+
+3. **Run `helm upgrade`** — the chart will create the SecretStore and ExternalSecret resources. ESO will sync your secrets from Key Vault into native Kubernetes Secrets.
+
+4. **Verify:** Check that secrets are synced:
+   ```bash
+   kubectl get externalsecrets -n <namespace>
+   # All should show STATUS = SecretSynced
+   kubectl get secretstore -n <namespace>
+   # Should show STATUS = Ready
+   ```
+
+5. **Clean up** (optional): Remove the CSI driver SecretProviderClass resources if no longer needed:
+   ```bash
+   kubectl delete secretproviderclass -n <namespace> --all
+   ```
+
+> **Note:** During migration, pods will restart to pick up the new secret source. Plan for a brief maintenance window in production.
                   
 ### GCP
 

--- a/nxrm-ha/templates/secretprovider.yaml
+++ b/nxrm-ha/templates/secretprovider.yaml
@@ -58,6 +58,9 @@ spec:
       {{- end }}
   parameters:
 {{- if .Values.azure.keyvault.enabled }}
+    {{- if .Values.secret.azure.clientID }}
+    clientID: {{ .Values.secret.azure.clientID }}
+    {{- end }}
     keyvaultName: {{.Values.secret.azure.keyvaultName}}
     useVMManagedIdentity: "{{ .Values.secret.azure.useVMManagedIdentity }}"
     userAssignedIdentityID: {{ .Values.secret.azure.userAssignedIdentityID }}

--- a/nxrm-ha/tests/eso-secret-store_test.yaml
+++ b/nxrm-ha/tests/eso-secret-store_test.yaml
@@ -55,3 +55,64 @@ tests:
             helm.sh/chart: nxrm-ha-latest
             foo: bar
             baz: bay
+
+  - it: should create secret store with Azure Key Vault WorkloadIdentity provider
+    set:
+      externalsecrets:
+        enabled: true
+        secretstore:
+          name: nexus-secret-store
+          spec:
+            provider:
+              azurekv:
+                authType: WorkloadIdentity
+                vaultUrl: "https://my-keyvault.vault.azure.net/"
+                serviceAccountRef:
+                  name: nexus-repository-dev-ha-sa
+    asserts:
+      - isKind:
+          of: SecretStore
+      - equal:
+          path: metadata.name
+          value: "nxrm-ha-nexus-secret-store"
+      - equal:
+          path: metadata.namespace
+          value: "nexusrepo"
+      - equal:
+          path: spec.provider
+          value:
+            azurekv:
+              authType: WorkloadIdentity
+              vaultUrl: "https://my-keyvault.vault.azure.net/"
+              serviceAccountRef:
+                name: nexus-repository-dev-ha-sa
+
+  - it: should not render secret store when externalsecrets.enabled is false
+    set:
+      externalsecrets:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render secret store when aws.secretmanager.enabled is true
+    set:
+      externalsecrets:
+        enabled: true
+      aws:
+        secretmanager:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render secret store when azure.keyvault.enabled is true
+    set:
+      externalsecrets:
+        enabled: true
+      azure:
+        keyvault:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/nxrm-ha/tests/secretprovider_test.yaml
+++ b/nxrm-ha/tests/secretprovider_test.yaml
@@ -268,3 +268,43 @@ tests:
       - equal:
           path: metadata.namespace
           value: "test-namespace"
+
+  - it: should render clientID in azure parameters when azure keyvault enabled
+    set:
+      secret:
+        secretProviderClass: "azureSecretProvider"
+        provider: "azure"
+        azure:
+          clientID: "my-workload-identity-client-id"
+      azure:
+        keyvault:
+          enabled: true
+    asserts:
+      - isKind:
+          of: SecretProviderClass
+      - equal:
+          path: spec.parameters.clientID
+          value: "my-workload-identity-client-id"
+
+  - it: should not render secret provider class when externalsecrets.enabled is true
+    set:
+      externalsecrets:
+        enabled: true
+      azure:
+        keyvault:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render secret provider class when neither aws nor azure is enabled
+    set:
+      aws:
+        secretmanager:
+          enabled: false
+      azure:
+        keyvault:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/nxrm-ha/tests/serviceaccount_test.yaml
+++ b/nxrm-ha/tests/serviceaccount_test.yaml
@@ -56,3 +56,37 @@ tests:
           path: metadata.namespace
           value: "test-namespace"
 
+  - it: should render Azure Workload Identity labels and annotations correctly
+    set:
+      serviceAccount:
+        enabled: true
+        name: nexus-repository-dev-ha-sa
+        labels:
+          azure.workload.identity/use: "true"
+        annotations:
+          azure.workload.identity/client-id: "abc123-client-id"
+          azure.workload.identity/tenant-id: "xyz789-tenant-id"
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: "nexus-repository-dev-ha-sa"
+      - isSubset:
+          path: metadata.labels
+          content:
+            azure.workload.identity/use: "true"
+      - equal:
+          path: metadata.annotations
+          value:
+            azure.workload.identity/client-id: "abc123-client-id"
+            azure.workload.identity/tenant-id: "xyz789-tenant-id"
+
+  - it: should not render service account when serviceAccount.enabled is false
+    set:
+      serviceAccount:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+

--- a/nxrm-ha/values.yaml
+++ b/nxrm-ha/values.yaml
@@ -11,11 +11,17 @@ serviceAccount:
   enabled: false
   name: nexus-repository-deployment-sa #This service account in managed by Helm
   labels: {}
-  annotations:
-    # Set annotations for service account. E.g. if deploying to AWS EKS
-    # and secrets manager is enabled then this role should have permissions for using secret manager.
-    # If using externaldns, role with route53 permissions needed by external-dns
-    # eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/nxrm-nexus-role
+  # For Azure Workload Identity, set:
+  # labels:
+  #   azure.workload.identity/use: "true"
+  annotations: {}
+  # For Azure Workload Identity, set:
+  # annotations:
+  #   azure.workload.identity/client-id: <your-azure-client-id>
+  #   azure.workload.identity/tenant-id: <your-azure-tenant-id>
+  # For AWS EKS with Secrets Manager or ExternalDNS, set:
+  # annotations:
+  #   eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/nxrm-nexus-role
 azure:
   enabled: false  #set to true to enable azure specific yamls/snippets
   keyvault:
@@ -258,6 +264,7 @@ externalsecrets:
     name: nexus-secret-store
     spec:
       provider:
+# Example for AWS Secrets Manager:
 #        aws:
 #          service: SecretsManager
 #          region: us-east-1
@@ -265,17 +272,13 @@ externalsecrets:
 #            jwt:
 #              serviceAccountRef:
 #                name: nexus-repository-deployment-sa # Use the same service account name as specified in serviceAccount.name
-# Example for Azure
-#    spec:
-#      provider:
+# Example for Azure Key Vault with Workload Identity:
 #        azurekv:
 #          authType: WorkloadIdentity
-#          vaultUrl: "https://xx-xxxx-xx.vault.azure.net"
+#          vaultUrl: "https://<keyvault-name>.vault.azure.net/"
 #          serviceAccountRef:
-#            name: nexus-repository-deployment-sa # Use the same service account name as specified in serviceAccount.name
-# Example for Google (GCP)
-#    spec:
-#      provider:
+#            name: nexus-repository-dev-ha-sa # Use the same service account name as specified in serviceAccount.name
+# Example for Google Secret Manager:
 #        gcpsm:
 #          projectID: "nxrm-gcp-deployments"
 #          auth:
@@ -349,6 +352,7 @@ secret:
   azure:
     # a managed identity or service principal that has secrets management access to the key vault
     userAssignedIdentityID: "userAssignedIdentityID"
+    clientID: "" # For Workload Identity mode: set to the AAD application or managed identity client ID
     tenantId: "azureTenantId"
     keyvaultName: yourazurekeyvault
     useVMManagedIdentity: true


### PR DESCRIPTION
 ## Summary
  
  Adds Azure Workload Identity support for AKS deployments using the External Secrets Operator (ESO), and incorporates the clientID fix from community PR #149 for the existing Secrets Store CSI Driver path.

  The Helm templates (serviceaccount.yaml, eso-secret-store.yaml) already supported arbitrary labels, annotations, and provider config via toYaml. This PR makes the feature properly available by documenting the
  correct configuration and adding tests that prove the path works end to end.

  ## Changes
  
  - templates/secretprovider.yaml — Added conditional clientID field to Azure CSI driver parameters (from community PR #149). Guarded by {{- if .Values.secret.azure.clientID }} so existing deployments without
  clientID are unaffected.
  - values.yaml — Added documented serviceAccount labels/annotations example for Azure Workload Identity; fixed structurally broken azurekv commented example (was duplicating spec: and provider: keys at wrong
  indentation level); added clientID field to secret.azure.
  - tests/serviceaccount_test.yaml — Added positive test for Azure WI labels/annotations rendering; added negative test for disabled service account.
  - tests/eso-secret-store_test.yaml — Added positive test for azurekv + WorkloadIdentity provider rendering; added negative tests for mutual exclusion with aws.secretmanager.enabled, azure.keyvault.enabled, and
  externalsecrets.enabled=false.
  - tests/secretprovider_test.yaml — Added positive test for clientID rendering; added negative tests for mutual exclusion with ESO and when neither AWS nor Azure is enabled.

  ## Test Plan

  - helm unittest nxrm-ha/ — 100/100 tests pass (up from 91)
  - helm lint nxrm-ha/ — 0 warnings, 0 failures
  - Existing CSI driver tests pass unchanged — backward compatibility confirmed
  - ESO and CSI driver mutual exclusion verified by negative tests

  ## Community PR #149

  Reviewed and incorporated the net-new clientID field addition for CSI driver Workload Identity mode. The change is guarded conditionally so it does not affect existing deployments.

  ## Backward Compatibility

  - Existing azure.keyvault.enabled: true (CSI driver) deployments: no change in rendered output unless secret.azure.clientID is explicitly set
  - Existing externalsecrets.enabled: true deployments: no change
  - Both methods remain mutually exclusive and independently functional