### PR TITLE
chore(eso): bump ExternalSecrets/SecretStore API to v1

### DIFF
--- a/nxrm-ha/templates/eso-admin-secrets.yaml
+++ b/nxrm-ha/templates/eso-admin-secrets.yaml
@@ -1,6 +1,6 @@
 {{- if and (not .Values.aws.secretmanager.enabled) (not .Values.azure.keyvault.enabled) (not .Values.secret.nexusAdminSecret.enabled) }}
 {{- if .Values.externalsecrets.enabled  }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ template "nexus.name" . }}-external-adminsecret

--- a/nxrm-ha/templates/eso-database-secrets.yaml
+++ b/nxrm-ha/templates/eso-database-secrets.yaml
@@ -1,6 +1,6 @@
 {{- if and (not .Values.aws.secretmanager.enabled) (not .Values.azure.keyvault.enabled) (not .Values.secret.dbSecret.enabled) }}
 {{- if .Values.externalsecrets.enabled  }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ template "nexus.name" . }}-external-dbsecret

--- a/nxrm-ha/templates/eso-license-secrets.yaml
+++ b/nxrm-ha/templates/eso-license-secrets.yaml
@@ -1,6 +1,6 @@
 {{- if and (not .Values.aws.secretmanager.enabled) (not .Values.azure.keyvault.enabled) (not .Values.secret.license.licenseSecret.enabled) }}
 {{- if .Values.externalsecrets.enabled  }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ template "nexus.name" . }}-external-{{ .Values.secret.license.name }}

--- a/nxrm-ha/templates/eso-nexus-secrets.yaml
+++ b/nxrm-ha/templates/eso-nexus-secrets.yaml
@@ -1,6 +1,6 @@
 {{- if and (not .Values.secret.aws.nexusSecret.enabled ) (not .Values.secret.azure.nexusSecret.enabled) (not .Values.secret.nexusSecret.enabled) }}
 {{- if and .Values.externalsecrets.enabled .Values.externalsecrets.secrets.nexusSecret.enabled }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ template "nexus.name" . }}-external-{{ .Values.secret.nexusSecret.name }}

--- a/nxrm-ha/templates/eso-secret-store.yaml
+++ b/nxrm-ha/templates/eso-secret-store.yaml
@@ -1,6 +1,6 @@
 {{- if and (not .Values.aws.secretmanager.enabled) (not .Values.azure.keyvault.enabled) (not .Values.secret.dbSecret.enabled) }}
 {{- if .Values.externalsecrets.enabled  }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: {{ template "nexus.name" . }}-{{ .Values.externalsecrets.secretstore.name }}


### PR DESCRIPTION
## Summary

Chart references `external-secrets.io/v1beta1` for `SecretStore` and `ExternalSecret` resources in five templates. ESO promoted these APIs to `v1` in the [0.10 release (Sep 2024)](https://github.com/external-secrets/external-secrets/releases/tag/v0.10.0) and `v1beta1` has since been removed. Customers running ESO ≥ 0.10 cannot apply the chart's ESO templates as-is.

One-line change per file: `v1beta1` → `v1`. Schema is identical for the resources rendered.

## Validation

End-to-end test against AKS with ESO 1.0.0 (current upstream release):

- `SecretStore` (azurekv + WorkloadIdentity path) reaches `Ready=True`
- All `ExternalSecret` resources reach `SecretSynced=True`
- Synced K8s Secrets contain expected keys with non-empty values
- `helm template` and `helm lint` pass

## Test plan

- [x] `helm lint nxrm-ha/` — clean
- [x] `helm template` — renders cleanly with new API version
- [x] Applied on AKS w/ ESO 1.0.0 — accepted by API server, sync verified

## Context

Pre-existing issue on `main`, exposed by #165 (Azure WorkloadIdentity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)