### PR TITLE
NEXUS-52146: Fix invalid helm-unittest assertions for pinned plugin 0.2.11

### DIFF
--- a/nxrm-ha/tests/ephemeral-storage_test.yaml
+++ b/nxrm-ha/tests/ephemeral-storage_test.yaml
@@ -169,7 +169,8 @@ tests:
           enabled: false
           path: "/nexus-data"
     asserts:
-      - notFailedTemplate: {}
+      - hasDocuments:
+          count: 0
 
   - it: should fail when logs path has trailing slash resolving to /nexus-data
     template: validate.yaml

--- a/nxrm-ha/tests/hpa_test.yaml
+++ b/nxrm-ha/tests/hpa_test.yaml
@@ -157,7 +157,7 @@ tests:
       hpa.targetMemoryUtilizationPercentage: 80
       statefulset.replicaCount: null
     asserts:
-      - notExists:
+      - isNull:
           path: spec.replicas
 
   # ── HPA namespace ────────────────────────────────────────────────────────────
@@ -221,7 +221,8 @@ tests:
   - it: should not fail validation when hpa is disabled (default)
     template: validate.yaml
     asserts:
-      - notFailedTemplate: {}
+      - hasDocuments:
+          count: 0
 
   - it: should not fail validation when hpa is enabled with valid config (no explicit replicaCount)
     template: validate.yaml
@@ -233,7 +234,8 @@ tests:
       hpa.targetMemoryUtilizationPercentage: 80
       statefulset.replicaCount: null
     asserts:
-      - notFailedTemplate: {}
+      - hasDocuments:
+          count: 0
 
   - it: should fail validation when maxReplicas is less than minReplicas
     template: validate.yaml


### PR DESCRIPTION
## NEXUS-52146

### Problem
The `nxrm-ha` chart unit tests (merged in #164) fail the build with:

```
FAIL  tests/hpa_test.yaml
    - Execution Error: Assertion type `notExists` is invalid
Tests:  0 passed, 0 total
```

The tests use assertion types that **do not exist** in the `quintush/helm-unittest` **0.2.11** fork pinned by `build.sh` (line 15). Those names (`notExists`, `notFailedTemplate`) only exist in the newer `helm-unittest/helm-unittest` fork. The `notExists` error is an *execution error* that aborts the whole suite before any test runs (hence `Tests: 0 total`), which masked two additional latent `notFailedTemplate` failures behind it.

### Fix
| File | Was | Now | Why |
|------|-----|-----|-----|
| `hpa_test.yaml:160` | `notExists` | `isNull` | asserts `spec.replicas` is absent when HPA is enabled |
| `hpa_test.yaml:224` | `notFailedTemplate: {}` | `hasDocuments: {count: 0}` | `validate.yaml` renders zero documents when validation passes |
| `hpa_test.yaml:236` | `notFailedTemplate: {}` | `hasDocuments: {count: 0}` | same |
| `ephemeral-storage_test.yaml:172` | `notFailedTemplate: {}` | `hasDocuments: {count: 0}` | same |

`validate.yaml` is a validation-only template (only `{{ fail }}` guards, no K8s resources), so it renders **empty** when valid. Asserting `hasDocuments: count 0` proves it rendered successfully without triggering a `fail`. If validation *had* failed, the render would error and the test would fail — which the `failedTemplate` test cases already cover.

### Verification
Run against the **exact CI plugin version** (`quintush/helm-unittest 0.2.11`):

```
helm lint ./nxrm-ha                                 -> 1 chart linted, 0 failed (exit 0)
(cd ./nxrm-ha; helm unittest -3 -t junit ... .)     -> 140/140 tests pass, 24 suites (exit 0)
```

### Note (out of scope)
The `0.2.11` `quintush` fork is archived/unmaintained. A local dev machine using the maintained `helm-unittest/helm-unittest` fork reports these tests as *passing* (it supports the newer assertion names) — a false green that hides this CI failure. Migrating `build.sh` to the maintained plugin would be worthwhile but is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)