### PR TITLE
NEXUS-52103: fix helm-unittest assertions for CI plugin version

### DIFF
--- a/nxrm-ha/tests/fluent-bit_test.yaml
+++ b/nxrm-ha/tests/fluent-bit_test.yaml
@@ -59,57 +59,57 @@ tests:
           value: "test-release-nxrm-ha-fluent-bit-config"
 
       - documentIndex: 4
-        exists:
-          path: data["nexus-log.conf"]
+        isNotNull:
+          path: data.[nexus-log.conf]
 
       - documentIndex: 4
-        exists:
-          path: data["nexus-request-log.conf"]
+        isNotNull:
+          path: data.[nexus-request-log.conf]
 
       - documentIndex: 4
-        exists:
-          path: data["nexus-audit-log.conf"]
+        isNotNull:
+          path: data.[nexus-audit-log.conf]
 
       - documentIndex: 4
-        exists:
-          path: data["nexus-tasks-log.conf"]
+        isNotNull:
+          path: data.[nexus-tasks-log.conf]
 
       - documentIndex: 4
-        exists:
-          path: data["nexus-outbound-log.conf"]
+        isNotNull:
+          path: data.[nexus-outbound-log.conf]
 
       - documentIndex: 4
-        exists:
-          path: data["nexus-jvm-log.conf"]
+        isNotNull:
+          path: data.[nexus-jvm-log.conf]
 
       - documentIndex: 4
         matchRegex:
-          path: data["fluent-bit.conf"]
+          path: data.[fluent-bit.conf]
           pattern: "@INCLUDE nexus-outbound-log.conf"
 
       - documentIndex: 4
         matchRegex:
-          path: data["fluent-bit.conf"]
+          path: data.[fluent-bit.conf]
           pattern: "@INCLUDE nexus-jvm-log.conf"
 
       - documentIndex: 4
         matchRegex:
-          path: data["nexus-outbound-log.conf"]
+          path: data.[nexus-outbound-log.conf]
           pattern: "Tag\\s+nexus.outbound-log"
 
       - documentIndex: 4
         matchRegex:
-          path: data["nexus-outbound-log.conf"]
+          path: data.[nexus-outbound-log.conf]
           pattern: "outbound-log-\\*\\.log"
 
       - documentIndex: 4
         matchRegex:
-          path: data["nexus-jvm-log.conf"]
+          path: data.[nexus-jvm-log.conf]
           pattern: "Tag\\s+nexus.jvm-log"
 
       - documentIndex: 4
         matchRegex:
-          path: data["nexus-jvm-log.conf"]
+          path: data.[nexus-jvm-log.conf]
           pattern: "jvm-log-\\*\\.log"
 
       - documentIndex: 5


### PR DESCRIPTION
## What

Fixes the `main` CI break introduced by #168. The fluent-bit unittest
assertions used syntax only supported by the newer helm-unittest fork,
but CI (`build.sh`) pins **quintush/helm-unittest v0.2.11**.

Two incompatibilities:
- `exists:` assertion → `Assertion type 'exists' is invalid`
- `data["key.with.dots"]` bracket paths → `missing index value`

## Why it passed locally but failed CI

Local machines had helm-unittest `1.1.1` (accepts both syntaxes); CI runs
`0.2.11` (does not). Classic local/CI version drift.

## Fix

In `nxrm-ha/tests/fluent-bit_test.yaml`:
- `exists:` → `isNotNull:` (already used elsewhere in the suite, passes on CI)
- `data["....conf"]` → `data.[....conf]` (jq-like syntax quintush 0.2.11 documents for dotted keys)

## Verification

Ran the **exact** plugin CI uses (quintush 0.2.11):
- Before: suite errored on `exists` (reproduced Jenkins #86).
- After: **142/142 pass**, `helm lint` clean.

NEXUS-52103
