### PR TITLE
NEXUS-53282: Add container-level securityContext for initContainer and log sidecars

### DIFF
--- a/nxrm-ha/templates/statefulset.yaml
+++ b/nxrm-ha/templates/statefulset.yaml
@@ -64,6 +64,10 @@ spec:
         {{- if .Values.ephemeralStorage.logs.enabled }}
         - name: init-ephemeral-log-dir
           image: busybox:1.33.1
+          {{- with .Values.statefulset.initContainer }}{{- if .securityContext }}
+          securityContext:
+            {{- toYaml .securityContext | nindent 12 }}
+          {{- end }}{{- end }}
           command: [/bin/sh]
           args:
             - -c
@@ -266,6 +270,10 @@ spec:
         {{- if .Values.logStorage.tailSecondaryLogs }}
         - name: request-log
           image: {{ .Values.statefulset.requestLogContainer.image.repository }}:{{ .Values.statefulset.requestLogContainer.image.tag }}
+          {{- with .Values.statefulset.requestLogContainer }}{{- if .securityContext }}
+          securityContext:
+            {{- toYaml .securityContext | nindent 12 }}
+          {{- end }}{{- end }}
           args: [/bin/sh, -c, 'tail -n+1 -F /nexus-data/log/request.log']
           volumeMounts:
             - name: nexus-data
@@ -278,6 +286,10 @@ spec:
             {{ toYaml .Values.statefulset.requestLogContainer.resources | nindent 12 }}
         - name: audit-log
           image: {{ .Values.statefulset.auditLogContainer.image.repository }}:{{ .Values.statefulset.auditLogContainer.image.tag }}
+          {{- with .Values.statefulset.auditLogContainer }}{{- if .securityContext }}
+          securityContext:
+            {{- toYaml .securityContext | nindent 12 }}
+          {{- end }}{{- end }}
           args: [/bin/sh, -c, 'tail -n+1 -F /nexus-data/log/audit/audit.log']
           volumeMounts:
             - name: nexus-data
@@ -291,6 +303,10 @@ spec:
         {{- if .Values.logStorage.combineTaskLogs }}
         - name: tasks-log
           image: {{ .Values.statefulset.taskLogContainer.image.repository }}:{{ .Values.statefulset.taskLogContainer.image.tag }}
+          {{- with .Values.statefulset.taskLogContainer }}{{- if .securityContext }}
+          securityContext:
+            {{- toYaml .securityContext | nindent 12 }}
+          {{- end }}{{- end }}
           args: [/bin/sh, -c, 'tail -n+1 -F /nexus-data/log/tasks/allTasks.log']
           volumeMounts:
             - name: nexus-data
@@ -304,6 +320,10 @@ spec:
         {{ end }}
         - name: outbound-log
           image: {{ .Values.statefulset.outboundLogContainer.image.repository }}:{{ .Values.statefulset.outboundLogContainer.image.tag }}
+          {{- with .Values.statefulset.outboundLogContainer }}{{- if .securityContext }}
+          securityContext:
+            {{- toYaml .securityContext | nindent 12 }}
+          {{- end }}{{- end }}
           args: [/bin/sh, -c, 'tail -n+1 -F /nexus-data/log/outbound-request.log']
           volumeMounts:
             - name: nexus-data
@@ -316,6 +336,10 @@ spec:
             {{ toYaml .Values.statefulset.outboundLogContainer.resources | nindent 12 }}
         - name: jvm-log
           image: {{ .Values.statefulset.jvmLogContainer.image.repository }}:{{ .Values.statefulset.jvmLogContainer.image.tag }}
+          {{- with .Values.statefulset.jvmLogContainer }}{{- if .securityContext }}
+          securityContext:
+            {{- toYaml .securityContext | nindent 12 }}
+          {{- end }}{{- end }}
           args: [/bin/sh, -c, 'tail -n+1 -F /nexus-data/log/jvm.log']
           volumeMounts:
             - name: nexus-data

--- a/nxrm-ha/tests/statefulset_test.yaml
+++ b/nxrm-ha/tests/statefulset_test.yaml
@@ -1193,3 +1193,166 @@ tests:
           value:
             - name: nexus-data
               mountPath: /nexus-data
+
+  - it: should not render securityContext on initContainer or sidecars by default
+    template: statefulset.yaml
+    set:
+      ephemeralStorage:
+        logs:
+          enabled: true
+      logStorage:
+        tailSecondaryLogs: true
+        combineTaskLogs: true
+    asserts:
+      - isNull:
+          path: spec.template.spec.initContainers[1].securityContext
+      - isNull:
+          path: spec.template.spec.containers[1].securityContext
+      - isNull:
+          path: spec.template.spec.containers[2].securityContext
+      - isNull:
+          path: spec.template.spec.containers[3].securityContext
+      - isNull:
+          path: spec.template.spec.containers[4].securityContext
+      - isNull:
+          path: spec.template.spec.containers[5].securityContext
+
+  - it: should set securityContext on the ephemeral log initContainer
+    template: statefulset.yaml
+    set:
+      ephemeralStorage:
+        logs:
+          enabled: true
+      statefulset:
+        initContainer:
+          securityContext:
+            runAsUser: 200
+            runAsGroup: 200
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: init-ephemeral-log-dir
+      - equal:
+          path: spec.template.spec.initContainers[1].securityContext
+          value:
+            runAsUser: 200
+            runAsGroup: 200
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+
+  - it: should set securityContext on the request-log sidecar
+    template: statefulset.yaml
+    set:
+      logStorage:
+        tailSecondaryLogs: true
+      statefulset:
+        requestLogContainer:
+          securityContext:
+            runAsUser: 200
+            runAsGroup: 200
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: request-log
+      - equal:
+          path: spec.template.spec.containers[1].securityContext
+          value:
+            runAsUser: 200
+            runAsGroup: 200
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+
+  - it: should set securityContext on the audit-log sidecar
+    template: statefulset.yaml
+    set:
+      logStorage:
+        tailSecondaryLogs: true
+      statefulset:
+        auditLogContainer:
+          securityContext:
+            runAsUser: 200
+            allowPrivilegeEscalation: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[2].name
+          value: audit-log
+      - equal:
+          path: spec.template.spec.containers[2].securityContext
+          value:
+            runAsUser: 200
+            allowPrivilegeEscalation: false
+
+  - it: should set securityContext on the tasks-log sidecar
+    template: statefulset.yaml
+    set:
+      logStorage:
+        tailSecondaryLogs: true
+        combineTaskLogs: true
+      statefulset:
+        taskLogContainer:
+          securityContext:
+            runAsUser: 200
+            allowPrivilegeEscalation: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[3].name
+          value: tasks-log
+      - equal:
+          path: spec.template.spec.containers[3].securityContext
+          value:
+            runAsUser: 200
+            allowPrivilegeEscalation: false
+
+  - it: should set securityContext on the outbound-log sidecar
+    template: statefulset.yaml
+    set:
+      logStorage:
+        tailSecondaryLogs: true
+        combineTaskLogs: true
+      statefulset:
+        outboundLogContainer:
+          securityContext:
+            runAsUser: 200
+            allowPrivilegeEscalation: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[4].name
+          value: outbound-log
+      - equal:
+          path: spec.template.spec.containers[4].securityContext
+          value:
+            runAsUser: 200
+            allowPrivilegeEscalation: false
+
+  - it: should set securityContext on the jvm-log sidecar
+    template: statefulset.yaml
+    set:
+      logStorage:
+        tailSecondaryLogs: true
+        combineTaskLogs: true
+      statefulset:
+        jvmLogContainer:
+          securityContext:
+            runAsUser: 200
+            allowPrivilegeEscalation: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[5].name
+          value: jvm-log
+      - equal:
+          path: spec.template.spec.containers[5].securityContext
+          value:
+            runAsUser: 200
+            allowPrivilegeEscalation: false

--- a/nxrm-ha/values.yaml
+++ b/nxrm-ha/values.yaml
@@ -67,6 +67,30 @@ statefulset:
   preStart:
     command: null
 
+  # Container-level securityContext for the chart's built-in 'init-ephemeral-log-dir'
+  # initContainer, which is created when ephemeralStorage.logs.enabled is true.
+  # Note this is distinct from 'initContainers' below, which is a list of your own
+  # additional init containers (each of those can carry its own securityContext inline).
+  initContainer:
+    # IMPORTANT: this initContainer runs 'chown -R 200:200' on the ephemeral log
+    # volume, so it must run as root (uid 0) and must retain the CHOWN capability.
+    # Setting runAsUser to a non-zero value, runAsNonRoot: true, or dropping ALL
+    # capabilities makes the chown fail, the initContainer exit non-zero, and the
+    # pod never starts. readOnlyRootFilesystem: true is safe - it only writes to
+    # the mounted volume.
+    securityContext: {}
+    # allowPrivilegeEscalation: false
+    # readOnlyRootFilesystem: true
+    # runAsUser: 0
+    # runAsNonRoot: false
+    # capabilities:
+    #   drop:
+    #     - ALL
+    #   add:
+    #     - CHOWN
+    #     - FOWNER
+    #     - DAC_OVERRIDE
+
   # # Add init containers. e.g. to be used to give specific permissions for nexus-data.
   # # Add your own init containers as needed
   initContainers:
@@ -144,6 +168,16 @@ statefulset:
     image:
       repository: busybox
       tag: 1.33.1
+    # Container-level securityContext for this log-tailing sidecar.
+    securityContext: {}
+    # allowPrivilegeEscalation: false
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 200
+    # runAsGroup: 200
+    # capabilities:
+    #   drop:
+    #     - ALL
     resources:
       limits:
         cpu: "0.2"
@@ -155,6 +189,16 @@ statefulset:
     image:
       repository: busybox
       tag: 1.33.1
+    # Container-level securityContext for this log-tailing sidecar.
+    securityContext: {}
+    # allowPrivilegeEscalation: false
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 200
+    # runAsGroup: 200
+    # capabilities:
+    #   drop:
+    #     - ALL
     resources:
       limits:
         cpu: "0.2"
@@ -166,6 +210,16 @@ statefulset:
     image:
       repository: busybox
       tag: 1.33.1
+    # Container-level securityContext for this log-tailing sidecar.
+    securityContext: {}
+    # allowPrivilegeEscalation: false
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 200
+    # runAsGroup: 200
+    # capabilities:
+    #   drop:
+    #     - ALL
     resources:
       limits:
         cpu: "0.2"
@@ -177,6 +231,16 @@ statefulset:
     image:
       repository: busybox
       tag: 1.33.1
+    # Container-level securityContext for this log-tailing sidecar.
+    securityContext: {}
+    # allowPrivilegeEscalation: false
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 200
+    # runAsGroup: 200
+    # capabilities:
+    #   drop:
+    #     - ALL
     resources:
       limits:
         cpu: "0.2"
@@ -188,6 +252,16 @@ statefulset:
     image:
       repository: busybox
       tag: 1.33.1
+    # Container-level securityContext for this log-tailing sidecar.
+    securityContext: {}
+    # allowPrivilegeEscalation: false
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 200
+    # runAsGroup: 200
+    # capabilities:
+    #   drop:
+    #     - ALL
     resources:
       limits:
         cpu: "0.2"


### PR DESCRIPTION
## Jira
https://sonatype.atlassian.net/browse/NEXUS-53282

## Change

Six new opt-in values, each rendering a container-level `securityContext` only
when set:

- `statefulset.initContainer.securityContext`
- `statefulset.requestLogContainer.securityContext`
- `statefulset.auditLogContainer.securityContext`
- `statefulset.taskLogContainer.securityContext`
- `statefulset.outboundLogContainer.securityContext`
- `statefulset.jvmLogContainer.securityContext`
All default to `{}` and render nothing, so **the default output is byte-identical
to `main`** — this is purely additive and opt-in, with no upgrade impact.

Template lookups are nil-safe (`{{- with … }}{{- if .securityContext }}`) so
charts whose values files predate these keys, or explicitly null them, still
render.
<img width="1622" height="348" alt="Before-fix" src="https://github.com/user-attachments/assets/0c9bd486-960c-41aa-86e2-76fc695d7456" />
<img width="1611" height="340" alt="After-fix" src="https://github.com/user-attachments/assets/609a90b2-6afe-448d-85bd-145cb7b432c4" />
