### PR TITLE
NEXUS-46386: Set securityContext on all containers for PodSecurity restricted compliance

### DIFF
--- a/nxrm-ha/README.md
+++ b/nxrm-ha/README.md
@@ -176,6 +176,66 @@ Existing users are unaffected — both `ephemeralStorage.logs.enabled` and `ephe
 HA supports all formats that PostgreSQL supports.
 
 
+## Pod Security Standards
+
+The chart sets a `securityContext` on the pod and on every container it creates, so it can be
+deployed to clusters that enforce the Kubernetes [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+(for example vSphere with Tanzu, OpenShift, or any namespace labelled
+`pod-security.kubernetes.io/enforce`).
+
+The defaults satisfy the **baseline** profile and are compliant with **restricted** for every
+container except the `chown-nexusdata-owner-to-nexus-and-init-log-dir` init container. That
+container runs `chown -R 200:200 /nexus-data` so the `nexus` user (uid/gid 200) owns its data
+directory, which requires either root or `CAP_CHOWN` — both rejected by `restricted`. The two
+requirements cannot be satisfied simultaneously, so the default keeps the chown.
+
+### Deploying to a namespace that enforces `restricted`
+
+Use the supplied overlay:
+
+```bash
+helm install nxrm-ha sonatype/nxrm-ha -f values-restricted.yaml
+```
+
+It removes the chown init container and instead sets `statefulset.podSecurityContext.fsGroup`,
+which makes the kubelet apply group ownership to mounted volumes — achieving the same result
+without a privileged step. Combine it with a cloud sample by listing it last, so its values win:
+
+```bash
+helm install nxrm-ha sonatype/nxrm-ha \
+  -f sample-gcp-ha-yamls/gcp-values-eso-enabled.yaml \
+  -f values-restricted.yaml
+```
+
+Trade-offs are documented in `values-restricted.yaml`. In short: the log sidecars may briefly
+crash-loop on a cold volume until `nxrm-app` creates the log files, and your CSI driver must
+honour `fsGroup` (all mainstream drivers do).
+
+### Overriding the defaults
+
+Each container's context is independently configurable:
+
+| Value | Applies to |
+| --- | --- |
+| `statefulset.podSecurityContext` | pod-level (`fsGroup`, `seccompProfile`, …) |
+| `nexus.securityContext` | the `nxrm-app` container |
+| `statefulset.initContainers[].securityContext` | your own init containers, set inline |
+| `statefulset.initContainer.securityContext` | the built-in ephemeral-log init container |
+| `statefulset.requestLogContainer.securityContext` | `request-log` sidecar |
+| `statefulset.auditLogContainer.securityContext` | `audit-log` sidecar |
+| `statefulset.taskLogContainer.securityContext` | `tasks-log` sidecar |
+| `statefulset.outboundLogContainer.securityContext` | `outbound-log` sidecar |
+| `statefulset.jvmLogContainer.securityContext` | `jvm-log` sidecar |
+| `aws.fluentbit.securityContext` | `fluent-bit` DaemonSet container |
+
+Helm deep-merges values, so to *remove* an inherited key rather than change it, set it to `null`
+explicitly (for example `capabilities.add: null`).
+
+> **Note:** the `fluent-bit` DaemonSet mounts `hostPath` volumes (`/var/log`,
+> `/var/lib/docker/containers`, `/run/log/journal`). `hostPath` is rejected by `restricted`
+> regardless of `securityContext`, so deploy it to a `baseline`/`privileged` namespace or
+> disable `aws.fluentbit` and forward logs another way.
+
 ## Deployment Configuration
 
 ### Secrets

--- a/nxrm-ha/templates/fluent-bit.yaml
+++ b/nxrm-ha/templates/fluent-bit.yaml
@@ -329,10 +329,18 @@ spec:
         version: v1
         kubernetes.io/cluster-service: "true"
     spec:
+      {{- with .Values.aws.fluentbit.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: fluent-bit
           image: amazon/aws-for-fluent-bit:{{ .Values.aws.fluentbit.fluentBitVersion }}
           imagePullPolicy: Always
+          {{- with .Values.aws.fluentbit.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: AWS_REGION
               valueFrom:

--- a/nxrm-ha/templates/statefulset.yaml
+++ b/nxrm-ha/templates/statefulset.yaml
@@ -78,8 +78,15 @@ spec:
               touch -a /ephemeral-logs/tasks/allTasks.log &&
               {{- end }}
               touch -a /ephemeral-logs/audit/audit.log &&
+              {{- if (dig "podSecurityContext" "fsGroup" nil .Values.statefulset) }}
+              touch -a /ephemeral-logs/request.log
+              {{- else }}
               touch -a /ephemeral-logs/request.log &&
+              {{/* Only chown when fsGroup is unset. With fsGroup the kubelet
+                   already owns the volume to that gid, and a chown here would
+                   fail anyway under PodSecurity 'restricted' (NEXUS-46386). */}}
               chown -R '200:200' /ephemeral-logs
+              {{- end }}
           volumeMounts:
             - name: nxrm-ephemeral-logs
               mountPath: /ephemeral-logs

--- a/nxrm-ha/tests/fluent-bit_test.yaml
+++ b/nxrm-ha/tests/fluent-bit_test.yaml
@@ -120,3 +120,48 @@ tests:
         equal:
           path: metadata.name
           value: "test-release-nxrm-ha-fluent-bit"
+  # NEXUS-46386: fluent-bit mounts hostPath volumes so it cannot satisfy the
+  # PodSecurity 'restricted' profile, but operators still need to set a
+  # securityContext to satisfy 'baseline' or their own admission controller.
+  - it: should not render a fluent-bit securityContext by default
+    set:
+      aws:
+        enabled: true
+        fluentbit:
+          enabled: true
+    asserts:
+      - documentIndex: 5
+        isNull:
+          path: spec.template.spec.securityContext
+      - documentIndex: 5
+        isNull:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: should render fluent-bit pod and container securityContext when set
+    set:
+      aws:
+        enabled: true
+        fluentbit:
+          enabled: true
+          podSecurityContext:
+            seccompProfile:
+              type: RuntimeDefault
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+    asserts:
+      - documentIndex: 5
+        equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - documentIndex: 5
+        equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - documentIndex: 5
+        equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          value:
+            - ALL

--- a/nxrm-ha/tests/statefulset_test.yaml
+++ b/nxrm-ha/tests/statefulset_test.yaml
@@ -1194,7 +1194,10 @@ tests:
             - name: nexus-data
               mountPath: /nexus-data
 
-  - it: should not render securityContext on initContainer or sidecars by default
+  # NEXUS-46386: this previously asserted securityContext was null by default.
+  # A null securityContext is exactly what PodSecurity 'restricted' rejects, so
+  # the chart now ships compliant defaults and the assertion is inverted.
+  - it: should render a securityContext on every initContainer and sidecar by default
     template: statefulset.yaml
     set:
       ephemeralStorage:
@@ -1204,17 +1207,21 @@ tests:
         tailSecondaryLogs: true
         combineTaskLogs: true
     asserts:
-      - isNull:
+      - isNotNull:
+          path: spec.template.spec.initContainers[0].securityContext
+      - isNotNull:
           path: spec.template.spec.initContainers[1].securityContext
-      - isNull:
+      - isNotNull:
+          path: spec.template.spec.containers[0].securityContext
+      - isNotNull:
           path: spec.template.spec.containers[1].securityContext
-      - isNull:
+      - isNotNull:
           path: spec.template.spec.containers[2].securityContext
-      - isNull:
+      - isNotNull:
           path: spec.template.spec.containers[3].securityContext
-      - isNull:
+      - isNotNull:
           path: spec.template.spec.containers[4].securityContext
-      - isNull:
+      - isNotNull:
           path: spec.template.spec.containers[5].securityContext
 
   - it: should set securityContext on the ephemeral log initContainer
@@ -1239,16 +1246,15 @@ tests:
           path: spec.template.spec.initContainers[1].name
           value: init-ephemeral-log-dir
       - equal:
-          path: spec.template.spec.initContainers[1].securityContext
+          path: spec.template.spec.initContainers[1].securityContext.runAsUser
+          value: 200
+      - equal:
+          path: spec.template.spec.initContainers[1].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.initContainers[1].securityContext.capabilities.drop
           value:
-            runAsUser: 200
-            runAsGroup: 200
-            runAsNonRoot: true
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop:
-                - ALL
+            - ALL
 
   - it: should set securityContext on the request-log sidecar
     template: statefulset.yaml
@@ -1267,12 +1273,11 @@ tests:
           path: spec.template.spec.containers[1].name
           value: request-log
       - equal:
-          path: spec.template.spec.containers[1].securityContext
-          value:
-            runAsUser: 200
-            runAsGroup: 200
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+          path: spec.template.spec.containers[1].securityContext.runAsUser
+          value: 200
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.readOnlyRootFilesystem
+          value: true
 
   - it: should set securityContext on the audit-log sidecar
     template: statefulset.yaml
@@ -1289,10 +1294,11 @@ tests:
           path: spec.template.spec.containers[2].name
           value: audit-log
       - equal:
-          path: spec.template.spec.containers[2].securityContext
-          value:
-            runAsUser: 200
-            allowPrivilegeEscalation: false
+          path: spec.template.spec.containers[2].securityContext.runAsUser
+          value: 200
+      - equal:
+          path: spec.template.spec.containers[2].securityContext.allowPrivilegeEscalation
+          value: false
 
   - it: should set securityContext on the tasks-log sidecar
     template: statefulset.yaml
@@ -1310,10 +1316,11 @@ tests:
           path: spec.template.spec.containers[3].name
           value: tasks-log
       - equal:
-          path: spec.template.spec.containers[3].securityContext
-          value:
-            runAsUser: 200
-            allowPrivilegeEscalation: false
+          path: spec.template.spec.containers[3].securityContext.runAsUser
+          value: 200
+      - equal:
+          path: spec.template.spec.containers[3].securityContext.allowPrivilegeEscalation
+          value: false
 
   - it: should set securityContext on the outbound-log sidecar
     template: statefulset.yaml
@@ -1331,10 +1338,11 @@ tests:
           path: spec.template.spec.containers[4].name
           value: outbound-log
       - equal:
-          path: spec.template.spec.containers[4].securityContext
-          value:
-            runAsUser: 200
-            allowPrivilegeEscalation: false
+          path: spec.template.spec.containers[4].securityContext.runAsUser
+          value: 200
+      - equal:
+          path: spec.template.spec.containers[4].securityContext.allowPrivilegeEscalation
+          value: false
 
   - it: should set securityContext on the jvm-log sidecar
     template: statefulset.yaml
@@ -1352,7 +1360,150 @@ tests:
           path: spec.template.spec.containers[5].name
           value: jvm-log
       - equal:
-          path: spec.template.spec.containers[5].securityContext
+          path: spec.template.spec.containers[5].securityContext.runAsUser
+          value: 200
+      - equal:
+          path: spec.template.spec.containers[5].securityContext.allowPrivilegeEscalation
+          value: false
+
+  # NEXUS-46386: chart must ship a PodSecurity 'restricted'-compliant pod spec
+  # out of the box. Every container needs allowPrivilegeEscalation=false,
+  # capabilities.drop=[ALL] and a seccompProfile, or admission rejects the pod.
+  - it: should set a restricted-compliant pod-level securityContext by default
+    template: statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 200
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 200
+      - equal:
+          path: spec.template.spec.securityContext.runAsGroup
+          value: 200
+
+  - it: should make nxrm-app restricted-compliant by default
+    template: statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: nxrm-app
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
           value:
-            runAsUser: 200
-            allowPrivilegeEscalation: false
+            - ALL
+
+  - it: should make the chown initContainer admission-compliant but keep CHOWN
+    template: statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: chown-nexusdata-owner-to-nexus-and-init-log-dir
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.drop
+          value:
+            - ALL
+      # must retain CHOWN: the container runs 'chown -R 200:200 /nexus-data'
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.add
+          value:
+            - CHOWN
+            - FOWNER
+            - DAC_OVERRIDE
+
+  - it: should make the ephemeral log initContainer admission-compliant by default
+    template: statefulset.yaml
+    set:
+      ephemeralStorage:
+        logs:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: init-ephemeral-log-dir
+      - equal:
+          path: spec.template.spec.initContainers[1].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.initContainers[1].securityContext.capabilities.add
+          value:
+            - CHOWN
+            - FOWNER
+            - DAC_OVERRIDE
+
+  - it: should make all log sidecars restricted-compliant by default
+    template: statefulset.yaml
+    set:
+      logStorage:
+        tailSecondaryLogs: true
+        combineTaskLogs: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.capabilities.drop
+          value:
+            - ALL
+      - equal:
+          path: spec.template.spec.containers[2].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[3].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[4].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[5].securityContext.allowPrivilegeEscalation
+          value: false
+
+  # NEXUS-46386: under PodSecurity 'restricted' the ephemeral-log initContainer
+  # cannot chown (no root, no CAP_CHOWN). When podSecurityContext.fsGroup is set
+  # the kubelet already owns the volume to that gid, so the chown must be
+  # omitted rather than fail at runtime.
+  - it: should omit the ephemeral chown when fsGroup handles volume ownership
+    template: statefulset.yaml
+    set:
+      ephemeralStorage:
+        logs:
+          enabled: true
+      statefulset:
+        podSecurityContext:
+          fsGroup: 200
+    asserts:
+      # index 1: the default chown-nexusdata initContainer occupies index 0
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: init-ephemeral-log-dir
+      - notMatchRegex:
+          path: spec.template.spec.initContainers[1].args[1]
+          pattern: chown
+
+  - it: should still chown the ephemeral logs when fsGroup is not set
+    template: statefulset.yaml
+    set:
+      ephemeralStorage:
+        logs:
+          enabled: true
+      statefulset:
+        podSecurityContext: null
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].args[1]
+          pattern: chown -R '200:200' /ephemeral-logs

--- a/nxrm-ha/values-restricted.yaml
+++ b/nxrm-ha/values-restricted.yaml
@@ -1,0 +1,72 @@
+# Overlay for clusters that enforce the Kubernetes PodSecurity "restricted"
+# profile with no exemptions -- for example vSphere with Tanzu, OpenShift's
+# restricted-v2 SCC, or any namespace labelled:
+#
+#   pod-security.kubernetes.io/enforce=restricted
+#
+# Usage:
+#   helm install nxrm-ha sonatype/nxrm-ha -f values-restricted.yaml
+#
+# WHY THIS FILE EXISTS
+#
+# The chart's default values are already compliant for every container except
+# the two init containers that run 'chown -R 200:200' over the data and log
+# volumes. A chown needs either root or CAP_CHOWN, and "restricted" forbids
+# both (runAsUser=0 and capabilities.add are rejected outright). The two
+# requirements cannot be satisfied at once, so the defaults keep the chown -- it
+# is the safer choice for the majority of clusters, which do not enforce
+# "restricted" -- and this overlay removes it for clusters that do.
+#
+# HOW IT WORKS INSTEAD
+#
+# statefulset.podSecurityContext.fsGroup makes the kubelet apply group
+# ownership to mounted volumes, which is what the chown was doing by hand. The
+# volume arrives already group-writable by gid 200, so no privileged init step
+# is needed. fsGroupChangePolicy: OnRootMismatch keeps restarts cheap by
+# skipping the recursive relabel when the top-level ownership already matches.
+#
+# TRADE-OFFS
+#
+#   * Removing the chown initContainer means the log sidecars may crash-loop and
+#     back off for a few seconds on a cold volume until nxrm-app creates the log
+#     files. Startup is slightly slower; it is self-healing.
+#   * fsGroup only fixes group ownership, not the owning uid. That is sufficient
+#     because Nexus runs as uid 200 / gid 200 and the volume is group-writable.
+#   * Requires a CSI driver that honours fsGroup. Every in-tree and mainstream
+#     CSI provider does; verify if you use an unusual storage backend.
+
+statefulset:
+  # Pod-level context: this is what replaces the chown.
+  podSecurityContext:
+    runAsUser: 200
+    runAsGroup: 200
+    runAsNonRoot: true
+    fsGroup: 200
+    fsGroupChangePolicy: "OnRootMismatch"
+    seccompProfile:
+      type: RuntimeDefault
+
+  # Drop the chown-nexusdata-owner-to-nexus-and-init-log-dir initContainer.
+  # fsGroup above makes it unnecessary, and it cannot satisfy "restricted".
+  initContainers: []
+
+  # Built-in ephemeral-log initContainer (only rendered when
+  # ephemeralStorage.logs.enabled=true). It also chowns, so under "restricted"
+  # it must run unprivileged and rely on fsGroup. The mkdir/touch it performs
+  # still work; only the chown is a no-op, which fsGroup has already handled.
+  initContainer:
+    securityContext:
+      runAsUser: 200
+      runAsGroup: 200
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+          - ALL
+        # Explicitly null, not merely omitted: Helm deep-merges values files, so
+        # leaving this out would inherit capabilities.add from values.yaml and
+        # admission would still reject the pod.
+        add: null

--- a/nxrm-ha/values.yaml
+++ b/nxrm-ha/values.yaml
@@ -39,6 +39,28 @@ aws:
     enabled: false #set this to true to enable sending of logs to CloudWatch
     fluentBitVersion: 2.28.0
     clusterName: nxrm-nexus
+    # securityContext for the fluent-bit DaemonSet (NEXUS-46386).
+    #
+    # Left empty on purpose. fluent-bit is a log-forwarding DaemonSet that mounts
+    # hostPath volumes (/var/log, /var/lib/docker/containers, /run/log/journal),
+    # and hostPath is rejected by the PodSecurity 'restricted' profile no matter
+    # what securityContext is set -- so this cannot be made 'restricted'-
+    # compliant. Deploy it to a namespace running 'baseline' or 'privileged', or
+    # disable aws.fluentbit and forward logs another way.
+    #
+    # These keys exist so you can still satisfy a 'baseline' policy or your own
+    # admission controller, eg:
+    #   podSecurityContext:
+    #     seccompProfile:
+    #       type: RuntimeDefault
+    #   securityContext:
+    #     allowPrivilegeEscalation: false
+    #     readOnlyRootFilesystem: false   # fluent-bit writes its state db
+    #     capabilities:
+    #       drop:
+    #         - ALL
+    podSecurityContext: {}
+    securityContext: {}
 statefulset:
   serviceName: nxrm-statefulset-service
   replicaCount: 3
@@ -46,9 +68,23 @@ statefulset:
   additionalVolumes:
   additionalVolumeMounts:
   additionalContainers:
-  podSecurityContext: {}
-  # fsGroup: 200
-  # fsGroupChangePolicy: "OnRootMismatch"
+  # Pod-level securityContext. Defaults satisfy the Kubernetes PodSecurity
+  # 'restricted' profile, which some platforms (eg. vSphere with Tanzu, or any
+  # namespace labelled pod-security.kubernetes.io/enforce=restricted) require
+  # before they will admit the pod at all.
+  #
+  # fsGroup makes the kubelet set group ownership on mounted volumes, so the
+  # nexus user (uid/gid 200) can write to /nexus-data without a privileged
+  # chown. fsGroupChangePolicy: OnRootMismatch keeps this cheap on restart by
+  # skipping the recursive relabel when the top-level ownership already matches.
+  podSecurityContext:
+    runAsUser: 200
+    runAsGroup: 200
+    runAsNonRoot: true
+    fsGroup: 200
+    fsGroupChangePolicy: "OnRootMismatch"
+    seccompProfile:
+      type: RuntimeDefault
   # # Add annotations to statefulset to enhance configurations
   annotations: {}
   podAnnotations: {}
@@ -78,18 +114,20 @@ statefulset:
     # capabilities makes the chown fail, the initContainer exit non-zero, and the
     # pod never starts. readOnlyRootFilesystem: true is safe - it only writes to
     # the mounted volume.
-    securityContext: {}
-    # allowPrivilegeEscalation: false
-    # readOnlyRootFilesystem: true
-    # runAsUser: 0
-    # runAsNonRoot: false
-    # capabilities:
-    #   drop:
-    #     - ALL
-    #   add:
-    #     - CHOWN
-    #     - FOWNER
-    #     - DAC_OVERRIDE
+    securityContext:
+      runAsUser: 0
+      runAsNonRoot: false
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+          - ALL
+        add:
+          - CHOWN
+          - FOWNER
+          - DAC_OVERRIDE
 
   # # Add init containers. e.g. to be used to give specific permissions for nexus-data.
   # # Add your own init containers as needed
@@ -99,6 +137,33 @@ statefulset:
     # for nxrm-app to start and this increases the total start up time.
     - name: chown-nexusdata-owner-to-nexus-and-init-log-dir
       image: busybox:1.33.1
+      # This container is injected verbatim into the pod spec, so its
+      # securityContext has to live here rather than in the template.
+      #
+      # It runs 'chown -R 200:200 /nexus-data', which needs CAP_CHOWN and root.
+      # Dropping ALL capabilities without adding CHOWN back makes the chown fail
+      # with "Operation not permitted", the initContainer exits non-zero, and the
+      # pod never starts. The settings below are what the 'restricted' profile
+      # checks (allowPrivilegeEscalation, capabilities.drop, seccompProfile)
+      # while still permitting the chown.
+      #
+      # To satisfy 'restricted' with no exemption at all, use
+      # values-restricted.yaml, which drops this container entirely and relies on
+      # statefulset.podSecurityContext.fsGroup for volume ownership instead.
+      securityContext:
+        runAsUser: 0
+        runAsNonRoot: false
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+            - ALL
+          add:
+            - CHOWN
+            - FOWNER
+            - DAC_OVERRIDE
       command: [/bin/sh]
       args:
         - -c
@@ -168,16 +233,20 @@ statefulset:
     image:
       repository: busybox
       tag: 1.33.1
-    # Container-level securityContext for this log-tailing sidecar.
-    securityContext: {}
-    # allowPrivilegeEscalation: false
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 200
-    # runAsGroup: 200
-    # capabilities:
-    #   drop:
-    #     - ALL
+    # Container-level securityContext for this log-tailing sidecar. It only reads
+    # log files from the shared volume, so it needs no capabilities at all and
+    # defaults to full PodSecurity 'restricted' compliance.
+    securityContext:
+      runAsUser: 200
+      runAsGroup: 200
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+          - ALL
     resources:
       limits:
         cpu: "0.2"
@@ -189,16 +258,20 @@ statefulset:
     image:
       repository: busybox
       tag: 1.33.1
-    # Container-level securityContext for this log-tailing sidecar.
-    securityContext: {}
-    # allowPrivilegeEscalation: false
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 200
-    # runAsGroup: 200
-    # capabilities:
-    #   drop:
-    #     - ALL
+    # Container-level securityContext for this log-tailing sidecar. It only reads
+    # log files from the shared volume, so it needs no capabilities at all and
+    # defaults to full PodSecurity 'restricted' compliance.
+    securityContext:
+      runAsUser: 200
+      runAsGroup: 200
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+          - ALL
     resources:
       limits:
         cpu: "0.2"
@@ -210,16 +283,20 @@ statefulset:
     image:
       repository: busybox
       tag: 1.33.1
-    # Container-level securityContext for this log-tailing sidecar.
-    securityContext: {}
-    # allowPrivilegeEscalation: false
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 200
-    # runAsGroup: 200
-    # capabilities:
-    #   drop:
-    #     - ALL
+    # Container-level securityContext for this log-tailing sidecar. It only reads
+    # log files from the shared volume, so it needs no capabilities at all and
+    # defaults to full PodSecurity 'restricted' compliance.
+    securityContext:
+      runAsUser: 200
+      runAsGroup: 200
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+          - ALL
     resources:
       limits:
         cpu: "0.2"
@@ -231,16 +308,20 @@ statefulset:
     image:
       repository: busybox
       tag: 1.33.1
-    # Container-level securityContext for this log-tailing sidecar.
-    securityContext: {}
-    # allowPrivilegeEscalation: false
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 200
-    # runAsGroup: 200
-    # capabilities:
-    #   drop:
-    #     - ALL
+    # Container-level securityContext for this log-tailing sidecar. It only reads
+    # log files from the shared volume, so it needs no capabilities at all and
+    # defaults to full PodSecurity 'restricted' compliance.
+    securityContext:
+      runAsUser: 200
+      runAsGroup: 200
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+          - ALL
     resources:
       limits:
         cpu: "0.2"
@@ -252,16 +333,20 @@ statefulset:
     image:
       repository: busybox
       tag: 1.33.1
-    # Container-level securityContext for this log-tailing sidecar.
-    securityContext: {}
-    # allowPrivilegeEscalation: false
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 200
-    # runAsGroup: 200
-    # capabilities:
-    #   drop:
-    #     - ALL
+    # Container-level securityContext for this log-tailing sidecar. It only reads
+    # log files from the shared volume, so it needs no capabilities at all and
+    # defaults to full PodSecurity 'restricted' compliance.
+    securityContext:
+      runAsUser: 200
+      runAsGroup: 200
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+          - ALL
     resources:
       limits:
         cpu: "0.2"
@@ -491,8 +576,24 @@ nexus:
   # Default the pods UID and GID to match the nexus3 container.
   # Customize or remove these values from the securityContext as appropriate for
   # your deployment environment.
+  #
+  # These defaults satisfy the PodSecurity 'restricted' profile. Note that
+  # runAsUser alone is not enough: 'restricted' also requires
+  # allowPrivilegeEscalation=false, capabilities.drop=[ALL], runAsNonRoot=true
+  # and a seccompProfile, otherwise admission rejects the whole pod.
+  #
+  # readOnlyRootFilesystem is deliberately NOT set here: Nexus writes to paths
+  # outside the /nexus-data mount (eg. its tmp and work directories).
   securityContext:
     runAsUser: 200
+    runAsGroup: 200
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+        - ALL
   properties:
     override: false
     data: null # specify a list of key and values to override default nexus.properties

--- a/sample-aws-ha-yamls/aws-ha-statefulset.yaml
+++ b/sample-aws-ha-yamls/aws-ha-statefulset.yaml
@@ -34,12 +34,37 @@ spec:
         app: nxrm
     spec:
       serviceAccountName: nexus-repository-ha-deployment-sa
+      # NEXUS-46386: pod-level context for PodSecurity-enforcing clusters.
+      # fsGroup lets the kubelet own mounted volumes to gid 200.
+      securityContext:
+        runAsUser: 200
+        runAsGroup: 200
+        runAsNonRoot: true
+        fsGroup: 200
+        fsGroupChangePolicy: "OnRootMismatch"
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
         # chown nexus-data to 'nexus' user and init log directories/files for a new pod
         # otherwise the side car containers will crash a couple of times and backoff whilst waiting
         # for nxrm-app to start and this increases the total start up time.
         - name: chown-nexusdata-owner-to-nexus-and-init-log-dir
           image: busybox:1.33.1
+          # Retains CHOWN: this container runs 'chown -R 200:200 /nexus-data'.
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - CHOWN
+                - FOWNER
+                - DAC_OVERRIDE
           command: [ /bin/sh ]
           args:
             - -c
@@ -75,6 +100,14 @@ spec:
               memory: "8Gi" #This is an example. Update as needed
           securityContext:
             runAsUser: 200
+            runAsGroup: 200
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8081

--- a/sample-azure-ha-yamls/azure-ha-kustomize-statefulset.yaml
+++ b/sample-azure-ha-yamls/azure-ha-kustomize-statefulset.yaml
@@ -35,12 +35,36 @@ spec:
       labels:
         app: nxrm
     spec:
+      # NEXUS-46386: pod-level context for PodSecurity-enforcing clusters.
+      securityContext:
+        runAsUser: 200
+        runAsGroup: 200
+        runAsNonRoot: true
+        fsGroup: 200
+        fsGroupChangePolicy: "OnRootMismatch"
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
         # chown nexus-data to 'nexus' user and init log directories/files for a new pod
         # otherwise the side car containers will crash a couple of times and backoff whilst waiting
         # for nxrm-app to start and this increases the total start up time.
         - name: chown-nexusdata-owner-to-nexus-and-init-log-dir
           image: busybox:1.33.1
+          # Retains CHOWN: runs 'chown -R 200:200 /nexus-data'.
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - CHOWN
+                - FOWNER
+                - DAC_OVERRIDE
           command: [/bin/sh]
           args:
             - -c
@@ -76,6 +100,14 @@ spec:
             memory: "8Gi"
         securityContext:
           runAsUser: 200
+          runAsGroup: 200
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop:
+              - ALL
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8081
@@ -123,6 +155,17 @@ spec:
             subPath: logback-tasklogfile-appender-override.xml
       - name: request-log
         image: busybox:1.33.1
+        securityContext:
+          runAsUser: 200
+          runAsGroup: 200
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop:
+              - ALL
         resources:
           limits:
             cpu: "0.2"
@@ -136,6 +179,17 @@ spec:
             mountPath: /nexus-data
       - name: audit-log
         image: busybox:1.33.1
+        securityContext:
+          runAsUser: 200
+          runAsGroup: 200
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop:
+              - ALL
         resources:
           limits:
             cpu: "0.2"
@@ -149,6 +203,17 @@ spec:
             mountPath: /nexus-data
       - name: tasks-log
         image: busybox:1.33.1
+        securityContext:
+          runAsUser: 200
+          runAsGroup: 200
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop:
+              - ALL
         resources:
           limits:
             cpu: "0.2"

--- a/sample-azure-ha-yamls/azure-ha-statefulset.yaml
+++ b/sample-azure-ha-yamls/azure-ha-statefulset.yaml
@@ -33,12 +33,37 @@ spec:
       labels:
         app: nxrm
     spec:
+      # NEXUS-46386: pod-level context for PodSecurity-enforcing clusters.
+      # fsGroup lets the kubelet own mounted volumes to gid 200.
+      securityContext:
+        runAsUser: 200
+        runAsGroup: 200
+        runAsNonRoot: true
+        fsGroup: 200
+        fsGroupChangePolicy: "OnRootMismatch"
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
         # chown nexus-data to 'nexus' user and init log directories/files for a new pod
         # otherwise the side car containers will crash a couple of times and backoff whilst waiting
         # for nxrm-app to start and this increases the total start up time.
         - name: chown-nexusdata-owner-to-nexus-and-init-log-dir
           image: busybox:1.33.1
+          # Retains CHOWN: this container runs 'chown -R 200:200 /nexus-data'.
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - CHOWN
+                - FOWNER
+                - DAC_OVERRIDE
           command: [/bin/sh]
           args:
             - -c
@@ -74,6 +99,14 @@ spec:
               memory: "8Gi" #This is an example. Update as needed
           securityContext:
             runAsUser: 200
+            runAsGroup: 200
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8081

--- a/sample-gcp-ha-yamls/gcp-ha-statefulset.yaml
+++ b/sample-gcp-ha-yamls/gcp-ha-statefulset.yaml
@@ -33,12 +33,37 @@ spec:
       labels:
         app: nxrm
     spec:
+      # NEXUS-46386: pod-level context for PodSecurity-enforcing clusters.
+      # fsGroup lets the kubelet own mounted volumes to gid 200.
+      securityContext:
+        runAsUser: 200
+        runAsGroup: 200
+        runAsNonRoot: true
+        fsGroup: 200
+        fsGroupChangePolicy: "OnRootMismatch"
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
         # chown nexus-data to 'nexus' user and init log directories/files for a new pod
         # otherwise the side car containers will crash a couple of times and backoff whilst waiting
         # for nxrm-app to start and this increases the total start up time.
         - name: chown-nexusdata-owner-to-nexus-and-init-log-dir
           image: busybox:1.33.1
+          # Retains CHOWN: this container runs 'chown -R 200:200 /nexus-data'.
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - CHOWN
+                - FOWNER
+                - DAC_OVERRIDE
           command: [/bin/sh]
           args:
             - -c
@@ -74,6 +99,14 @@ spec:
               memory: "8Gi" #This is an example. Update as needed
           securityContext:
             runAsUser: 200
+            runAsGroup: 200
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8081

--- a/sample-gcp-ha-yamls/gcp-values-eso-disabled.yaml
+++ b/sample-gcp-ha-yamls/gcp-values-eso-disabled.yaml
@@ -29,6 +29,22 @@ statefulset:
   initContainers:
     - name: chown-nexusdata-owner-to-nexus-and-init-log-dir
       image: busybox:1.33.1
+      # NEXUS-46386: needed for PodSecurity-enforcing clusters. Retains CHOWN
+      # because this container runs 'chown -R 200:200 /nexus-data'.
+      securityContext:
+        runAsUser: 0
+        runAsNonRoot: false
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+            - ALL
+          add:
+            - CHOWN
+            - FOWNER
+            - DAC_OVERRIDE
       command: [/bin/sh]
       args:
         - -c

--- a/sample-gcp-ha-yamls/gcp-values-eso-enabled.yaml
+++ b/sample-gcp-ha-yamls/gcp-values-eso-enabled.yaml
@@ -29,6 +29,22 @@ statefulset:
   initContainers:
     - name: chown-nexusdata-owner-to-nexus-and-init-log-dir
       image: busybox:1.33.1
+      # NEXUS-46386: needed for PodSecurity-enforcing clusters. Retains CHOWN
+      # because this container runs 'chown -R 200:200 /nexus-data'.
+      securityContext:
+        runAsUser: 0
+        runAsNonRoot: false
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+            - ALL
+          add:
+            - CHOWN
+            - FOWNER
+            - DAC_OVERRIDE
       command: [/bin/sh]
       args:
         - -c


### PR DESCRIPTION

Link: https://sonatype.atlassian.net/browse/NEXUS-46386

### Problem

Clusters that enforce the Kubernetes PodSecurity `restricted` profile (vSphere with Tanzu,
OpenShift, or any namespace labelled `pod-security.kubernetes.io/enforce=restricted`) refuse to
admit the HA chart's pod, so the StatefulSet never starts a single replica:

```
create Pod nxrm-ha-0 in StatefulSet nxrm-ha failed error: pods "nxrm-ha-0" is forbidden:
violates PodSecurity "restricted:latest": allowPrivilegeEscalation != false (containers
"chown-nexusdata-owner-to-nexus-and-init-log-dir", "request-log", "audit-log", "tasks-log" ...)
```

Customer-reported and escalated, with no workaround.

### Root cause

Three separate gaps, all reproduced against a live PodSecurity admission controller:

1. **Empty defaults.** PR #172 (NEXUS-53282) added per-container `securityContext` plumbing for the
   ephemeral init container and the five log sidecars, but every default is `securityContext: {}`.
   The template guards on `{{- if .securityContext }}`, and an empty map is falsy in Helm, so
   nothing rendered. The mechanism worked; the shipped defaults were the gap.
2. **`chown-nexusdata-owner-to-nexus-and-init-log-dir` was unreachable by that fix.** It is not in
   the template — it is data in `values.yaml`, injected via a raw
   `{{ toYaml .Values.statefulset.initContainers }}` passthrough. No template-side guard can reach
   inside it, which is why the ticket's primary symptom survived PR #172.
3. **`nxrm-app` was only partially compliant.** `nexus.securityContext` set `runAsUser: 200` alone;
   `restricted` also requires `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`,
   `runAsNonRoot: true` and a `seccompProfile`.

**Key constraint:** both init containers run `chown -R 200:200`, which needs root or `CAP_CHOWN` —
both forbidden by `restricted`. The requirements are mutually exclusive, so the fix cannot simply
harden every container. Verified empirically: a fully-restricted chown container fails with
`chown: Operation not permitted`, while pod-level `fsGroup: 200` achieves the same ownership with
no privileged step.

### Fix

- `values.yaml` — `statefulset.podSecurityContext` now defaults to a compliant pod-level context
  including `fsGroup: 200`, `fsGroupChangePolicy: OnRootMismatch` and `seccompProfile`.
- `values.yaml` — added a `securityContext` to the `chown-nexusdata-...` init container (the one
  PR #172 could not reach). Retains `CHOWN`/`FOWNER`/`DAC_OVERRIDE` so the chown still works.
- `values.yaml` — populated the six empty `securityContext: {}` defaults (ephemeral init container
  + five log sidecars). Sidecars only tail files, so they get no capabilities at all.
- `values.yaml` — extended `nexus.securityContext` to full compliance for `nxrm-app`.
  `readOnlyRootFilesystem` deliberately omitted: Nexus writes outside `/nexus-data`.
- `templates/statefulset.yaml` — the ephemeral `chown` is now skipped when `fsGroup` is set, since
  the kubelet already owns the volume and the chown would fail under `restricted`. Uses `dig` for
  nil-safety when a user sets `podSecurityContext: null`.
- `values-restricted.yaml` (new) — overlay for no-exemption `restricted` clusters. Drops the chown
  init container and relies on `fsGroup`.
- `templates/fluent-bit.yaml` + `values.yaml` — added configurable pod/container `securityContext`.
  Left empty by default and documented: fluent-bit mounts `hostPath` volumes, which `restricted`
  rejects regardless of `securityContext`, so it cannot be made compliant.
- `README.md` — new "Pod Security Standards" section: the constraint, the overlay, a per-container
  override table, and the Helm `null` merge caveat.
- Six sample files under `sample-{aws,gcp,azure}-ha-yamls/` updated. The values-style GCP samples
  override `initContainers` wholesale and would otherwise have silently reverted the fix.

### Cross-format impact

Not format-parallel. This is a Helm chart / deployment-descriptor change in
`sonatype/nxrm3-ha-repository` with no Java or repository-format code involved, so the
26-format parallel-defect scan does not apply.

### Tests added

`helm unittest`, 149 → 158 passing (24 suites). Each was written RED and observed failing first.

- `statefulset_test.yaml` — pod-level compliance; `nxrm-app` compliance; chown init container keeps
  `CHOWN`; ephemeral init container compliance; all five sidecars compliant by default; chown
  omitted when `fsGroup` set; chown retained when it is not.
- `fluent-bit_test.yaml` — no `securityContext` by default; pod and container contexts render when
  set.

One pre-existing test was **inverted**: `should not render securityContext on initContainer or
sidecars by default` asserted the null `securityContext` that is precisely this defect. It now
asserts the opposite. Six PR-172 override tests moved from whole-map `equal` to field-level
assertions, because `--set` now merges with non-empty defaults rather than replacing an empty map.

### Verification

Tested against real PodSecurity admission (kind v0.32.0, Kubernetes v1.36.1, namespace labelled
`enforce=restricted`), not just rendered YAML:

| | Verdict |
| --- | --- |
| BEFORE — `origin/main` defaults | REJECTED (8 containers, 4 violation classes) |
| AFTER — chart defaults | REJECTED (2 chown containers only) — intentional, baseline-compatible |
| AFTER — `+ values-restricted.yaml` | **ADMITTED** |

The middle row is by design: the defaults keep the privileged chown because that is correct for the
majority of clusters which do not enforce `restricted`.

Runtime verified too, since admission passing does not prove containers work:

- restricted overlay, real init-container command → **Succeeded**, exit 0
- default path with privileged chown → **Succeeded**, exit 0

Also: admission regression matrix 8/8 admitted across all log/storage/clustering toggles;
`helm lint` clean; `kubeconform -strict` 10/10 valid; both GCP values samples admitted when
combined with the overlay as documented.

Three bugs were caught by testing and fixed before this PR: a Helm map-merge that left
`capabilities.add` inherited (needed explicit `add: null`), a nil-pointer when
`podSecurityContext: null`, and the ephemeral chown failing at runtime under the overlay.

### Notes for reviewers

- **Behaviour change:** the chart now ships a non-empty `podSecurityContext` and per-container
  contexts. Changed pod-spec defaults trigger a StatefulSet rollout on upgrade.
- **Not validated on vSphere/Tanzu** — no such environment is available (noted in the ticket).
  Validated against the upstream PodSecurity standard that Tanzu enforces.
- A full `helm install` of Nexus was not run: the chart requests 8 GiB/8 CPU per pod versus 7.7 GiB
  on the test VM. Admission is the ticket's failure mode and does not require it; both
  init-container paths were run as real containers.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
